### PR TITLE
Changes to support running gotest and gocheck in container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ SHELL := /usr/bin/env bash
 include project.mk
 include standard.mk
 
-default: gobuild
+# by default build .godirs file, do NOT run this inside a container build
+default: .godirs gobuild
 
 # Extend Makefile after here
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,5 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
-# Allow specifying a GOPROXY cache during build to speed up dependency resolution
-ARG GOPROXY=https://proxy.golang.org
-
-ENV GO111MODULE=on \
-    GOPROXY=$GOPROXY
-
 COPY . /workdir
 WORKDIR /workdir
 COPY go.mod go.sum ./


### PR DESCRIPTION
Also making a change to align env/args in Dockerfile and Makefile w/ managed-velero-operator in an attempt to fix prow integration. https://github.com/openshift/release/pull/7597