### PR TITLE
Add logic to remove external LB from master machine's ProviderSpecs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -14,6 +14,8 @@ rules:
     - get
     - list
     - watch
+    - patch
+    - update
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/controller/utils/clusterinfo.go
+++ b/pkg/controller/utils/clusterinfo.go
@@ -100,6 +100,21 @@ func GetClusterRegion(kclient client.Client) (string, error) {
 	return infra.Status.PlatformStatus.AWS.Region, nil
 }
 
+// GetMasterNodes returns a machineList object whose .Items can be iterated
+// over to perform actions on/with information from each master machine object
+func GetMasterNodes(kclient client.Client) (*machineapi.MachineList, error) {
+	machineList := &machineapi.MachineList{}
+	listOptions := []client.ListOption{
+		client.InNamespace("openshift-machine-api"),
+		client.MatchingLabels{masterMachineLabel: "master"},
+	}
+	err := kclient.List(context.TODO(), machineList, listOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return machineList, nil
+}
+
 // GetClusterMasterInstancesIDs gets all the instance IDs for Master nodes
 // For AWS the form is aws:///<availability zone>/<instance ID>
 // This could come from parsing the arbitrarily formatted .Status.ProviderStatus


### PR DESCRIPTION
when setting defaultAPIServerIngress to internal