### PR TITLE
Make routeSelector field optional

### DIFF
--- a/deploy/crds/cloudingress.managed.openshift.io_publishingstrategies_crd.yaml
+++ b/deploy/crds/cloudingress.managed.openshift.io_publishingstrategies_crd.yaml
@@ -111,7 +111,6 @@ spec:
                 - certificate
                 - default
                 - dnsName
-                - routeSelector
                 type: object
               type: array
             defaultAPIServerIngress:

--- a/pkg/apis/cloudingress/v1alpha1/publishingstrategy_types.go
+++ b/pkg/apis/cloudingress/v1alpha1/publishingstrategy_types.go
@@ -34,7 +34,7 @@ type ApplicationIngress struct {
 	Default       bool                   `json:"default"`
 	DNSName       string                 `json:"dnsName"`
 	Certificate   corev1.SecretReference `json:"certificate"`
-	RouteSelector metav1.LabelSelector   `json:"routeSelector"`
+	RouteSelector metav1.LabelSelector   `json:"routeSelector,omitempty"`
 }
 
 // Listening defines internal or external api and ingress

--- a/pkg/apis/cloudingress/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/cloudingress/v1alpha1/zz_generated.openapi.go
@@ -26,14 +26,14 @@ func schema_pkg_apis_cloudingress_v1alpha1_APIScheme(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -67,8 +67,19 @@ func schema_pkg_apis_cloudingress_v1alpha1_APISchemeSpec(ref common.ReferenceCal
 			SchemaProps: spec.SchemaProps{
 				Description: "APISchemeSpec defines the desired state of APIScheme",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"managementAPIServerIngress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Ref:         ref("github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1.ManagementAPIServerIngress"),
+						},
+					},
+				},
+				Required: []string{"managementAPIServerIngress"},
 			},
 		},
+		Dependencies: []string{
+			"github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1.ManagementAPIServerIngress"},
 	}
 }
 
@@ -78,7 +89,36 @@ func schema_pkg_apis_cloudingress_v1alpha1_APISchemeStatus(ref common.ReferenceC
 			SchemaProps: spec.SchemaProps{
 				Description: "APISchemeStatus defines the observed state of APIScheme",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"cloudLoadBalancerDNSName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1.APISchemeCondition"),
+									},
+								},
+							},
+						},
+					},
+					"state": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
 			},
 		},
+		Dependencies: []string{
+			"github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1.APISchemeCondition"},
 	}
 }

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -214,7 +214,7 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 		err = r.client.Create(context.TODO(), newIngressController)
 		if err != nil {
 			if k8serr.IsAlreadyExists(err) {
-				log.Info("default ingresscontroller already exists on cluster. Enter retry...")
+				log.Info("ingresscontroller already exists on cluster. Enter retry...")
 				for i := 0; i < 30; i++ {
 					if i == 30 {
 						log.Error(err, "out of retries")

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -170,8 +170,8 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 			if err != nil {
 				if k8serr.IsAlreadyExists(err) {
 					log.Info("default ingresscontroller already exists on cluster. Enter retry...")
-					for i := 0; i < 30; i++ {
-						if i == 30 {
+					for i := 0; i < 60; i++ {
+						if i == 60 {
 							log.Error(err, "out of retries")
 							return reconcile.Result{}, err
 						}


### PR DESCRIPTION
Currently the PublishingStrategy CR will not build if the routeSelector struct is not defined. This PR makes this field optional so OCM will not have to define the routeSelector if not needed.

EDIT: we also set our ingresscontroller creation retries from 30 seconds to 60 seconds.