### PR TITLE
Use 'Sync' instead of 'sync' for resourceApplyMode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ include functions.mk
 default: generate-syncset gobuild
 
 # Extend Makefile after here
+CONTAINER_ENGINE?=docker
 
 # Build the docker image
 .PHONY: container-build
@@ -27,7 +28,7 @@ operator-sdk-generate:
 .PHONY: generate-syncset
 generate-syncset:
 	if [ "${IN_CONTAINER}" == "true" ]; then \
-		docker run --rm -v `pwd -P`:`pwd -P` python:2.7.15 /bin/sh -c "cd `pwd`; pip install oyaml; `pwd`/${GEN_SYNCSET}"; \
+		$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` python:2.7.15 /bin/sh -c "cd `pwd`; pip install oyaml; `pwd`/${GEN_SYNCSET}"; \
 	else \
 		${GEN_SYNCSET}; \
 	fi

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -43,7 +43,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: sync
+    resourceApplyMode: Sync
     resources:
     - kind: Namespace
       apiVersion: v1
@@ -115,6 +115,16 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - ingresscontrollers
+        verbs:
+        - get
+        - list
+        - watch
+        - delete
+        - create
       - apiGroups:
         - config.openshift.io
         resources:
@@ -311,7 +321,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: sync
+    resourceApplyMode: Sync
     resources:
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
@@ -501,7 +511,6 @@ objects:
                       - certificate
                       - default
                       - dnsName
-                      - routeSelector
                       type: object
                     type: array
                   defaultAPIServerIngress:

--- a/hack/templates/selectorsyncset.yaml
+++ b/hack/templates/selectorsyncset.yaml
@@ -10,4 +10,4 @@ spec:
   clusterDeploymentSelector:
     matchLabels:
       api.openshift.com/managed: "true"
-  resourceApplyMode: sync
+  resourceApplyMode: Sync


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3163

Had to put back the CONTAINER_ENGINE variable to build.
Locally had to set IS_CONTAINER to get a good generated template.
And someone didn't run make to generate template recently?