### PR TITLE
Clean up the 'sleeping x second' messages

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -363,7 +363,6 @@ func (r *ReconcilePublishingStrategy) defaultIngressHandle(appingress cloudingre
 					log.Error(err, "out of retries")
 					return err
 				}
-				log.Info(fmt.Sprintf("sleeping %d second before retrying again", i))
 				time.Sleep(time.Duration(1) * time.Second)
 
 				err = r.client.Create(context.TODO(), newDefaultIngressController)
@@ -412,7 +411,6 @@ func (r *ReconcilePublishingStrategy) nonDefaultIngressHandle(appingress cloudin
 					log.Error(err, "out of retries")
 					return err
 				}
-				log.Info(fmt.Sprintf("sleeping %d second before retrying again", i))
 				time.Sleep(time.Duration(1) * time.Second)
 
 				err = r.client.Create(context.TODO(), newIngressController)


### PR DESCRIPTION
Currently we are logging every second that we retry the creation of ingresscontroller. This PR removes those logs.