### PR TITLE
Only deploy to AWS clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,6 +27,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+        hive.openshift.io/cluster-platform: aws
     resourceApplyMode: Sync
     resources:
     - kind: Namespace
@@ -296,6 +297,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+        hive.openshift.io/cluster-platform: aws
     resourceApplyMode: Sync
     resources:
     - apiVersion: apiextensions.k8s.io/v1beta1

--- a/hack/templates/selectorsyncset.yaml
+++ b/hack/templates/selectorsyncset.yaml
@@ -10,4 +10,5 @@ spec:
   clusterDeploymentSelector:
     matchLabels:
       api.openshift.com/managed: "true"
+      hive.openshift.io/cluster-platform: "aws"
   resourceApplyMode: Sync


### PR DESCRIPTION
This is needed to prevent the cloud-ingress-operator from being deployed to OSD on GCP clusters