### PR TITLE
Match LB short name for removal

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -198,23 +198,23 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 
 		var intDNSName string
 		var intHostedZoneID string
-		var extDNSName string
+		var lbName string
 		// delete the external NLB
 		for _, loadBalancer := range loadBalancerInfo {
 			if loadBalancer.Scheme == "internet-facing" {
-				extDNSName = loadBalancer.DNSName
-				log.Info("Trying to remove external LB", "LB", extDNSName)
+				lbName = loadBalancer.LoadBalancerName
+				log.Info("Trying to remove external LB", "LB", lbName)
 				err = awsClient.DeleteExternalLoadBalancer(loadBalancer.LoadBalancerArn)
 				if err != nil {
 					log.Error(err, "error deleting external LB")
 					return reconcile.Result{}, err
 				}
-				err := utils.RemoveAWSLBFromMasterMachines(r.client, extDNSName, masterList)
+				err := utils.RemoveAWSLBFromMasterMachines(r.client, lbName, masterList)
 				if err != nil {
 					log.Error(err, "Error removing external LB from master machine objects")
 					return reconcile.Result{}, err
 				}
-				log.Info("Load balancer removed from master machine objects", "LB", extDNSName)
+				log.Info("Load balancer removed from master machine objects", "LB", lbName)
 				log.Info(fmt.Sprintf("external LB %v deleted", loadBalancer.LoadBalancerArn))
 			}
 			// get internal dnsName and HostID for UpsertCNAME func

--- a/pkg/controller/utils/machine_helper.go
+++ b/pkg/controller/utils/machine_helper.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"reflect"
-	"strings"
 
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -27,7 +26,7 @@ func RemoveAWSLBFromMasterMachines(kclient client.Client, elbName string, master
 		lbList := providerSpecDecoded.LoadBalancers
 		newLBList := []awsproviderapi.LoadBalancerReference{}
 		for _, lb := range lbList {
-			if !strings.HasPrefix(elbName, lb.Name) {
+			if lb.Name != elbName {
 				log.Info("Machine's LB does not match LB to remove", "Machine LB", lb.Name, "LB to remove", elbName)
 				log.Info("Keeping machine's LB in machine object", "LB", lb.Name, "Machine", machine.Name)
 				newLBList = append(newLBList, lb)


### PR DESCRIPTION
Previously when removing a load balancer, we were matching a substring
of its DNS name. With this commit, we pass in the "short name" so we can
do an exact match.