### PR TITLE
Add comments for {Add|Remove}AWSLB{To|From}MasterMachines

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -202,6 +202,9 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 		// delete the external NLB
 		for _, loadBalancer := range loadBalancerInfo {
 			if loadBalancer.Scheme == "internet-facing" {
+				// TODO: Could/should we use loadBalancer.LoadBalancerName here instead? Would that be
+				// guaranteed to match the LoadBalancerRefenece.Name from AWSMachineProviderConfig.LoadBalancers[]?
+				// See the NOTEs in RemoveAWSLBFromMasterMachines.
 				extDNSName = loadBalancer.DNSName
 				log.Info("Trying to remove external LB", "LB", extDNSName)
 				err = awsClient.DeleteExternalLoadBalancer(loadBalancer.LoadBalancerArn)


### PR DESCRIPTION
machine_helper.AddAWSLBToMasterMachines and
.RemoveAWSLBFromMasterMachines both take an argument called `elbName`,
but are expecting different versions of the LB name for $reasons. This
was confusing to me, reading the code for the first time, so this commit
adds explanatory comments so future me isn't as confused.