### PR TITLE
Add tags for external NLB

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,7 @@ github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad h1:MiZEukiPd7ll8BQDw
 github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190617165122-8892c0adc000/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
+github.com/openshift/cluster-api-provider-aws v0.2.0 h1:WcOAGKSEMY8kt4a4kLkRaJQahLkvWnUK0O5kPiTLKWY=
 github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c h1:Xy9oQu/23dWIfb16kuSwev++aCwszRPBdqwdMGYw0Zk=
 github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c/go.mod h1:ZoUVLK6Sz9wmeVsD0Vc2AmHY3rJeAWQyQW2uRW7vwh4=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -84,6 +84,8 @@ type Client interface {
 	CreateListenerV2(*elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error)
 	// describes the targetGroup for NLB
 	DescribeTargetGroupsV2(*elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error)
+	// add tags for an NLB
+	AddTagsV2(*elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error)
 
 	/*
 	 * Route 53-related Functions
@@ -287,6 +289,10 @@ func (c *AwsClient) RegisterInstancesWithLoadBalancer(i *elb.RegisterInstancesWi
 
 func (c *AwsClient) DescribeTargetGroupsV2(i *elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
 	return c.elbv2Client.DescribeTargetGroups(i)
+}
+
+func (c *AwsClient) AddTagsV2(i *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error) {
+	return c.elbv2Client.AddTags(i)
 }
 
 func (c *AwsClient) ChangeResourceRecordSets(i *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {

--- a/pkg/awsclient/elb_helper.go
+++ b/pkg/awsclient/elb_helper.go
@@ -267,6 +267,31 @@ func (c *AwsClient) CreateListenerForNLB(targetGroupArn, loadBalancerArn string)
 	return nil
 }
 
+// AddTagsForNLB creates needed tags for an NLB
+func (c *AwsClient) AddTagsForNLB(resourceARN string, clusterName string) error {
+	i := &elbv2.AddTagsInput{
+		ResourceArns: []*string{
+			aws.String(resourceARN), // ext nlb resources arn
+		},
+		Tags: []*elbv2.Tag{
+			{
+				Key:   aws.String("kubernetes.io/cluster/" + clusterName),
+				Value: aws.String("owned"),
+			},
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(clusterName + "-ext"), //in form of samn-test-qb58m-ext
+			},
+		},
+	}
+
+	_, err := c.AddTagsV2(i)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetTargetGroupArn by passing in targetGroup Name
 func (c *AwsClient) GetTargetGroupArn(targetGroupName string) (string, error) {
 	i := &elbv2.DescribeTargetGroupsInput{

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -258,7 +258,7 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 			}
 		}
 
-		// create a new external NLB (TODO: add tags)
+		// create a new external NLB
 		infrastructureName, err := utils.GetClusterName(r.client)
 		if err != nil {
 			log.Error(err, "cannot get infrastructure name")
@@ -289,6 +289,11 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 		if len(newNLBs) != 1 {
 			log.Error(err, "more than one NLB or no NLB detected, but we expect one")
 			return reconcile.Result{}, err
+		}
+
+		err = awsClient.AddTagsForNLB(newNLBs[0].LoadBalancerArn, infrastructureName)
+		if err != nil {
+			log.Error(err, "Couldn't add tags for external NLB")
 		}
 
 		// ATTEMPT TO USE EXISTING TG


### PR DESCRIPTION
Currently when creating an external NLB we do not have any tags. This PR fixes that issue by creating two appropriate tags at creation time of the external NLB