### PR TITLE
OSD-3391, BZ 1814332: Handle missing infra PlatformStatus

### DIFF
--- a/deploy/20_cluster_config_v1_reader_role.yaml
+++ b/deploy/20_cluster_config_v1_reader_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cluster-config-v1-reader
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-config-v1
+  resources:
+  - configmaps
+  verbs:
+  - get

--- a/deploy/20_cluster_config_v1_reader_role.yaml
+++ b/deploy/20_cluster_config_v1_reader_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: cluster-config-v1-reader
+  name: cluster-config-v1-reader-cio
   namespace: kube-system
 rules:
 - apiGroups:

--- a/deploy/20_cluster_config_v1_reader_role_binding.yaml
+++ b/deploy/20_cluster_config_v1_reader_role_binding.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-ingress-operator-cluster-config-v1-reader
+  namespace: kube-system
+  labels:
+    owner: cloud-ingress-operator
+    owner.namespace: openshift-cloud-ingress-operator
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-config-v1-reader

--- a/deploy/20_cluster_config_v1_reader_role_binding.yaml
+++ b/deploy/20_cluster_config_v1_reader_role_binding.yaml
@@ -13,4 +13,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cluster-config-v1-reader
+  name: cluster-config-v1-reader-cio

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/utils v0.0.0-20191217005138-9e5e9d854fcc
 	sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 // Pinned to kubernetes-1.16.2

--- a/go.sum
+++ b/go.sum
@@ -909,6 +909,8 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
@@ -1001,4 +1003,6 @@ sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -207,7 +207,7 @@ objects:
       kind: Role
       metadata:
         creationTimestamp: null
-        name: cluster-config-v1-reader
+        name: cluster-config-v1-reader-cio
         namespace: kube-system
       rules:
       - apiGroups:
@@ -233,7 +233,7 @@ objects:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: cluster-config-v1-reader
+        name: cluster-config-v1-reader-cio
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -203,6 +203,37 @@ objects:
         - deployments
         verbs:
         - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: cluster-config-v1-reader
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - cluster-config-v1
+        resources:
+        - configmaps
+        verbs:
+        - get
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: cloud-ingress-operator-cluster-config-v1-reader
+        namespace: kube-system
+        labels:
+          owner: cloud-ingress-operator
+          owner.namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: cluster-config-v1-reader
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/pkg/controller/utils/clusterinfo_test.go
+++ b/pkg/controller/utils/clusterinfo_test.go
@@ -23,6 +23,25 @@ func TestClusterBaseDomain(t *testing.T) {
 	}
 }
 
+// BZ https://bugzilla.redhat.com/show_bug.cgi?id=1814332
+func TestOldClusterNoInfrastructureBackfill(t *testing.T) {
+	clustername := "oldtest"
+	// legacy infra obj has this extra bits, but the configmap does not
+	extrabits := "cmld7"
+	oldInfraObj := testutils.CreatOldInfraObject("oldtest-cmld7", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
+	oldCM := testutils.CreateLegacyClusterConfig(fmt.Sprintf("%s.%s", clustername, testutils.DefaultClusterDomain),
+		fmt.Sprintf("%s-%s", clustername, extrabits), testutils.DefaultRegionName, 0, 0)
+	objs := []runtime.Object{oldInfraObj, oldCM}
+	mocks := testutils.NewTestMock(t, objs)
+	region, err := GetClusterRegion(mocks.FakeKubeClient)
+	if err != nil {
+		t.Fatalf("Error: Couldn't get region. Expected to get %s: %v", testutils.DefaultRegionName, err)
+	}
+	if region != testutils.DefaultRegionName {
+		t.Fatalf("Expected region to be %s, but got %s", testutils.DefaultRegionName, region)
+	}
+}
+
 func TestGetClusterPlatform(t *testing.T) {
 	infraObj := testutils.CreateInfraObject("basename", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
 	objs := []runtime.Object{infraObj}


### PR DESCRIPTION
Some older, upgraded clusters currently lack the `PlatformStatus` in the
`Infrastructure` object, and so this works around it by referencing the
(deprecated) cluster-config-v1 configmap out of kube-system namespace.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>