### PR TITLE
Fix deletion for ingress

### DIFF
--- a/standard.mk
+++ b/standard.mk
@@ -34,7 +34,7 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 CONTAINER_ENGINE=$(shell which podman 2>/dev/null || which docker 2>/dev/null)
 
 # ex, -v
-TESTOPTS :=
+TESTOPTS := -timeout 1m
 
 ALLOW_DIRTY_CHECKOUT?=false
 


### PR DESCRIPTION
Currently deletion of ingresscontroller are being triggered every reconcile loop. This PR fixes that by:

- only deleting if necessary (e.g ingress listening has been changed).
- only delete non-default ingress with correct annotation.