### PR TITLE
generate_template.py: Always use block style in dump()

### DIFF
--- a/hack/generate_template.py
+++ b/hack/generate_template.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
 
     # write template file ordering by keys
     with open(arguments.destination,'w') as outfile:
-        yaml.dump(template_data, outfile)
+        yaml.dump(template_data, outfile, default_flow_style=False)


### PR DESCRIPTION
Make it explicit to always use "block" style in `yaml.dump()`.

At least on my system, `generate_template.py` keeps reverting `olm-artifacts-template.yaml` to the default "flow" style every time I run `make`.

See **Dictionaries without nested collections are not dumped correctly** in the FAQ section of the [PyYAML documentation](https://pyyaml.org/wiki/PyYAMLDocumentation).