### PR TITLE
Revert "OSD-3564: Use native Service object to create ELB"

### DIFF
--- a/pkg/awsclient/ec2_helper.go
+++ b/pkg/awsclient/ec2_helper.go
@@ -3,7 +3,262 @@ package awsclient
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elb"
 )
+
+// TODO: Handle errors, where possible, instead of returning to caller.
+
+// EnsureCIDRAccess ensures that for the given load balancer, the specified CIDR
+// blocks, and only those blocks may access it.
+// cidrBlocks always goes from source:6443/TCP to target:6443/TCP and is IPv4 only
+// TODO: Expand to IPv6. This could be done by regular expression
+func (c *AwsClient) EnsureCIDRAccess(loadBalancerName, securityGroupName, vpcID string, cidrBlocks []string, ownerTag map[string]string) error {
+	// first need to see if the SecurityGroup exists, and if it does not, create it and populate its ingressCIDR permissions
+	// If the SecurityGroup DOES exist, then make sure it only has the permissions we are receiving here.
+	securityGroup, err := c.findSecurityGroupByName(securityGroupName)
+	if err != nil {
+		return err
+	}
+	if securityGroup == nil {
+		// group does not exist, create it
+		securityGroup, err = c.createSecurityGroup(securityGroupName, vpcID, ownerTag)
+		if err != nil {
+			return err
+		}
+	}
+	// At this point, securityGroup is unified, no matter how we got it:
+	// finding it, or creating it and so now we can reconcile the rules
+
+	var rulesToRemove, rulesToAdd []*ec2.IpPermission
+
+	// When processing all this SecurityGroup's ingress rules we compare
+	// to cidrBlocks, but that doesn't always hit the expected set, so
+	// this is a map to see if we have done just that. Any which are
+	// false were not processed.
+	seenExpectedRules := make(map[string]bool)
+	// init map
+	for _, cidrBlock := range cidrBlocks {
+		seenExpectedRules[cidrBlock] = false
+	}
+	// Structure to determine which rules we have seen in the AWS side of the
+	// Security Group that aren't in the authoritative list ('cidrBlocks'). As they
+	// are observed in the following loop, they are set to "false" to mean they SHOULD be removed
+	// The remaining CIDR blocks (expressed as the key) with a true value represent
+	// Security Group ingress rules to remove.
+	cidrBlocksToKeep := make(map[string]bool)
+
+	for _, desiredCidrBlock := range cidrBlocks {
+		// Search for desiredCidrBlock in AWS
+		for _, ipPermission := range securityGroup.IpPermissions {
+			// Only care about 6443/TCP -> 6443/TCP
+			if *ipPermission.FromPort != 6443 &&
+				*ipPermission.ToPort != 6443 &&
+				*ipPermission.IpProtocol != "tcp" {
+				continue
+			}
+			for _, ingressRule := range ipPermission.IpRanges {
+				// By default, we should want to remove the rule unless in the check immediately
+				// following we determine that we wish to have this rule.
+				if !cidrBlocksToKeep[*ingressRule.CidrIp] {
+					// This looks weird, but the way this works is that map[string]bool have a
+					// default of false for any absent string key. Since we always want to default
+					// to removal we need to set all cidr blocks to false. However, since we
+					// encounter each one multiple times (after they might be set true, below), we
+					// only want to do this if they're NOT true (eg, decided to keep it).
+					cidrBlocksToKeep[*ingressRule.CidrIp] = false
+				}
+				if *ingressRule.CidrIp == desiredCidrBlock {
+					// The desired CIDR block is in fact in AWS.
+					seenExpectedRules[desiredCidrBlock] = true
+					cidrBlocksToKeep[*ingressRule.CidrIp] = true
+				}
+			}
+		}
+	}
+	// Turn the CIDR blocks to remove map into a slice of *ec2.IpPermission objects
+	// for use later passing to the removal method
+	for cidrBlock, removeThisBlock := range cidrBlocksToKeep {
+		if !removeThisBlock {
+			rulesToRemove = append(rulesToRemove, &ec2.IpPermission{
+				FromPort:   aws.Int64(6443),
+				ToPort:     aws.Int64(6443),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      aws.String(cidrBlock),
+						Description: aws.String("Approved CIDR Block from cloud-ingress-operator configuration"),
+					},
+				},
+			})
+		}
+	}
+
+	for cidrBlock, seen := range seenExpectedRules {
+		if !seen {
+			rulesToAdd = append(rulesToAdd, &ec2.IpPermission{
+				FromPort:   aws.Int64(6443),
+				ToPort:     aws.Int64(6443),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      aws.String(cidrBlock),
+						Description: aws.String("Approved CIDR Block from cloud-ingress-operator configuration"),
+					},
+				},
+			})
+		}
+	}
+	if err := c.addIngressRulesToSecurityGroup(securityGroup, rulesToAdd); err != nil {
+		return err
+	}
+	if err := c.removeIngressRulesFromSecurityGroup(securityGroup, rulesToRemove); err != nil {
+		return err
+	}
+	// Once the ingress rules are updated, attach the SecurityGroup to the load balancer
+	return c.setLoadBalancerSecurityGroup(loadBalancerName, securityGroup)
+}
+
+// Add rules to the security group
+func (c *AwsClient) addIngressRulesToSecurityGroup(securityGroup *ec2.SecurityGroup, ipPermissions []*ec2.IpPermission) error {
+	if len(ipPermissions) == 0 {
+		// nothing to do
+		return nil
+	}
+	i := &ec2.AuthorizeSecurityGroupIngressInput{
+		IpPermissions: ipPermissions,
+		GroupId:       securityGroup.GroupId,
+	}
+	_, err := c.AuthorizeSecurityGroupIngress(i)
+	return err
+}
+
+// Remove rules from the security group
+func (c *AwsClient) removeIngressRulesFromSecurityGroup(securityGroup *ec2.SecurityGroup, ipPermissions []*ec2.IpPermission) error {
+	if len(ipPermissions) == 0 {
+		// nothing   to do
+		return nil
+	}
+	i := &ec2.RevokeSecurityGroupIngressInput{
+		IpPermissions: ipPermissions,
+		GroupId:       securityGroup.GroupId,
+	}
+	_, err := c.RevokeSecurityGroupIngress(i)
+	return err
+}
+
+// createSecurityGroup creates a SecurityGroup with the given name, and returns the EC2 object and/or any error
+func (c *AwsClient) createSecurityGroup(securityGroupName, vpcID string, ownerTag map[string]string) (*ec2.SecurityGroup, error) {
+	createInput := &ec2.CreateSecurityGroupInput{
+		Description: aws.String("Admin API Security group"),
+		GroupName:   aws.String(securityGroupName),
+		VpcId:       aws.String(vpcID),
+	}
+	createResult, err := c.CreateSecurityGroup(createInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply tags
+
+	err = c.ApplyTagsToResources([]string{*createResult.GroupId}, ownerTag)
+	if err != nil {
+		return nil, err
+	}
+	// Caller of this method wants a *ec2.SecurityGroup, and since the create
+	// method doesn't give us nought but the group-id, we have to do a search
+	// to find it.
+	return c.findSecurityGroupByID(*createResult.GroupId)
+}
+
+func (c *AwsClient) findSecurityGroupByID(id string) (*ec2.SecurityGroup, error) {
+
+	i := &ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: aws.StringSlice([]string{id}),
+			},
+		},
+	}
+	o, err := c.DescribeSecurityGroups(i)
+	if err != nil {
+		return nil, err
+	}
+	if len(o.SecurityGroups) == 0 {
+		return nil, nil
+	}
+	return o.SecurityGroups[0], nil
+}
+
+func (c *AwsClient) findSecurityGroupByName(name string) (*ec2.SecurityGroup, error) {
+
+	i := &ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("group-name"),
+				Values: aws.StringSlice([]string{name}),
+			},
+		},
+	}
+	o, err := c.DescribeSecurityGroups(i)
+	if err != nil {
+		return nil, err
+	}
+	if len(o.SecurityGroups) == 0 {
+		return nil, nil
+	}
+	return o.SecurityGroups[0], nil
+}
+
+// Add a SecurityGroup to a load balancer. This is an idempotent operation
+func (c *AwsClient) setLoadBalancerSecurityGroup(loadBalancerName string, securityGroup *ec2.SecurityGroup) error {
+
+	i := &elb.ApplySecurityGroupsToLoadBalancerInput{
+		LoadBalancerName: aws.String(loadBalancerName),
+		SecurityGroups:   aws.StringSlice([]string{*securityGroup.GroupId}),
+	}
+	_, err := c.ApplySecurityGroupsToLoadBalancer(i)
+	return err
+}
+
+// ApplyTagsToResources will apply the specified tags to the resource IDs specified.
+func (c *AwsClient) ApplyTagsToResources(resources []string, tagList map[string]string) error {
+	tags := make([]*ec2.Tag, 0)
+	for k, v := range tagList {
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	i := &ec2.CreateTagsInput{
+		Resources: aws.StringSlice(resources),
+		Tags:      tags,
+	}
+
+	_, err := c.CreateTags(i)
+	return err
+}
+
+// SubnetIDToVPCLookup will return the VPC IDs of the given Subnet IDs
+func (c *AwsClient) SubnetIDToVPCLookup(subnetID []string) ([]string, error) {
+	i := &ec2.DescribeSubnetsInput{
+		SubnetIds: aws.StringSlice(subnetID),
+	}
+	r, err := c.DescribeSubnets(i)
+	vpcs := make([]string, 0)
+	if err != nil {
+		return vpcs, err
+	}
+	dedup := make(map[string]bool)
+	for _, subnet := range r.Subnets {
+		if !dedup[*subnet.VpcId] {
+			vpcs = append(vpcs, *subnet.VpcId)
+			dedup[*subnet.VpcId] = true
+		}
+
+	}
+	return vpcs, nil
+}
 
 // SubnetNameToSubnetIDLookup takes a slice of names and turns them into IDs.
 // The return is the same order as the names: name[0] -> return[0]

--- a/pkg/awsclient/elb_helper.go
+++ b/pkg/awsclient/elb_helper.go
@@ -1,6 +1,8 @@
 package awsclient
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -12,6 +14,142 @@ type AWSLoadBalancer struct {
 	ELBName   string // Name of the ELB
 	DNSName   string // DNS Name of the ELB
 	DNSZoneId string // Zone ID
+}
+
+// MapToELBTags will turn a map[string]string into a slice of *elb.Tag
+func (c *AwsClient) MapToELBTags(tags map[string]string) []*elb.Tag {
+	ret := make([]*elb.Tag, 0)
+	for k, v := range tags {
+		ret = append(ret, &elb.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return ret
+}
+
+// CreateClassicELB creates a classic ELB in Amazon, as in for management API endpoint.
+// inputs are the name of the ELB, the availability zone(s) and subnet(s) the
+// ELB should attend, as well as the listener port.
+// The port is used for the instance port and load balancer port
+// Return is the (FQDN) DNS name from Amazon, and error, if any.
+func (c *AwsClient) CreateClassicELB(elbName string, subnets []string, listenerPort int64, tagList map[string]string) (*AWSLoadBalancer, error) {
+	tags := c.MapToELBTags(tagList)
+
+	i := &elb.CreateLoadBalancerInput{
+		LoadBalancerName: aws.String(elbName),
+		Subnets:          aws.StringSlice(subnets),
+		//AvailabilityZones: aws.StringSlice(availabilityZones),
+		Listeners: []*elb.Listener{
+			{
+				InstancePort:     aws.Int64(listenerPort),
+				InstanceProtocol: aws.String("tcp"),
+				Protocol:         aws.String("tcp"),
+				LoadBalancerPort: aws.Int64(listenerPort),
+			},
+		},
+		Tags: tags,
+	}
+	_, err := c.CreateLoadBalancer(i)
+	if err != nil {
+		return &AWSLoadBalancer{}, err
+	}
+	err = c.addHealthCheck(elbName, "TCP", "/", 6443)
+	if err != nil {
+		return &AWSLoadBalancer{}, err
+	}
+	// Caller will need the DNS name and Zone ID for the ELB (for route53) so let's make a handy object to return, using the
+	_, awsELBObj, err := c.DoesELBExist(elbName)
+	if err != nil {
+		return &AWSLoadBalancer{}, err
+	}
+	return awsELBObj, nil
+}
+
+// RemoveLoadBalancerListeners sets a load balancer private by removing its
+// listeners (port 6443/TCP)
+func (c *AwsClient) RemoveLoadBalancerListeners(elbName string) error {
+	return c.removeListenersFromELB(elbName)
+}
+
+// AddLoadBalancerListeners will set the specified load balancer public by
+// re-adding the 6443/TCP -> 6443/TCP listener. Any instances (still)
+// attached to the load balancer will begin to receive traffic.
+func (c *AwsClient) AddLoadBalancerListeners(elbName string, listenerPort int64) error {
+	l := []*elb.Listener{
+		{
+			InstancePort:     aws.Int64(listenerPort),
+			InstanceProtocol: aws.String("tcp"),
+			Protocol:         aws.String("tcp"),
+			LoadBalancerPort: aws.Int64(listenerPort),
+		},
+	}
+	return c.addListenersToELB(elbName, l)
+}
+
+// removeListenersFromELB will remove the 6443/TCP -> 6443/TCP listener from
+// the specified ELB. This is useful when the "ext" ELB is to be no longer
+// publicly accessible
+func (c *AwsClient) removeListenersFromELB(elbName string) error {
+
+	i := &elb.DeleteLoadBalancerListenersInput{
+		LoadBalancerName:  aws.String(elbName),
+		LoadBalancerPorts: aws.Int64Slice([]int64{6443}),
+	}
+	_, err := c.DeleteLoadBalancerListeners(i)
+	return err
+}
+
+// addListenersToELB will add the +listeners+ to the specified ELB. This is
+// useful for when the "ext" ELB is to be publicly accessible. See also
+// removeListenersFromELB.
+// Note: This will likely always want to be given 6443/tcp -> 6443/tcp for
+// the kube-api
+func (c *AwsClient) addListenersToELB(elbName string, listeners []*elb.Listener) error {
+
+	i := &elb.CreateLoadBalancerListenersInput{
+		Listeners:        listeners,
+		LoadBalancerName: aws.String(elbName),
+	}
+	_, err := c.CreateLoadBalancerListeners(i)
+	return err
+}
+
+// AddLoadBalancerInstances will attach +instanceIds+ to +elbName+
+// so that they begin to receive traffic. Note that this takes an amount of
+// time to return. This is also additive (but idempotent - TODO: Validate this).
+// Note that the recommended steps:
+// 1. stop the instance,
+// 2. deregister the instance,
+// 3. start the instance,
+// 4. and then register the instance.
+func (c *AwsClient) AddLoadBalancerInstances(elbName string, instanceIds []string) error {
+
+	instances := make([]*elb.Instance, 0)
+	for _, instance := range instanceIds {
+		instances = append(instances, &elb.Instance{InstanceId: aws.String(instance)})
+	}
+	i := &elb.RegisterInstancesWithLoadBalancerInput{
+		Instances:        instances,
+		LoadBalancerName: aws.String(elbName),
+	}
+	_, err := c.RegisterInstancesWithLoadBalancer(i)
+	return err
+}
+
+// RemoveInstancesFromLoadBalancer removes +instanceIds+ from +elbName+, eg when an Node is deleted.
+func (c *AwsClient) RemoveInstancesFromLoadBalancer(elbName string, instanceIds []string) error {
+
+	instances := make([]*elb.Instance, 0)
+	for _, instance := range instanceIds {
+		instances = append(instances, &elb.Instance{InstanceId: aws.String(instance)})
+	}
+	i := &elb.DeregisterInstancesFromLoadBalancerInput{
+		Instances:        instances,
+		LoadBalancerName: aws.String(elbName),
+	}
+	_, err := c.DeregisterInstancesFromLoadBalancer(i)
+	return err
 }
 
 // DoesELBExist checks for the existence of an ELB by name. If there's an AWS
@@ -167,4 +305,19 @@ func (c *AwsClient) GetTargetGroupArn(targetGroupName string) (string, error) {
 		return "", err
 	}
 	return aws.StringValue(result.TargetGroups[0].TargetGroupArn), nil
+}
+
+func (c *AwsClient) addHealthCheck(loadBalancerName, protocol, path string, port int64) error {
+	i := &elb.ConfigureHealthCheckInput{
+		HealthCheck: &elb.HealthCheck{
+			HealthyThreshold:   aws.Int64(2),
+			Interval:           aws.Int64(30),
+			Target:             aws.String(fmt.Sprintf("%s:%d%s", protocol, port, path)),
+			Timeout:            aws.Int64(3),
+			UnhealthyThreshold: aws.Int64(2),
+		},
+		LoadBalancerName: aws.String(loadBalancerName),
+	}
+	_, err := c.ConfigureHealthCheck(i)
+	return err
 }

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -12,9 +12,8 @@ import (
 
 	utils "github.com/openshift/cloud-ingress-operator/pkg/controller/utils"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,17 +78,33 @@ type ReconcileAPIScheme struct {
 // LoadBalancer contains the relevant information to create a Load Balancer
 // TODO: Move this into pkg/client
 type LoadBalancer struct {
-	EndpointName string // FQDN of what it should be called
-	BaseDomain   string // What is the base domain (DNS zone) for the EndpointName record?
+	EndpointName     string            // FQDN of what it should be called
+	BaseDomain       string            // What is the base domain (DNS zone) for the EndpointName record?
+	Subnets          []string          // On which subnets it should operate (provider-native IDs)
+	Tags             map[string]string // Map of tags to apply to the Load Balancer
+	MachineInstances []string          // What are the cloud provider instance IDs that should receive traffic?
+}
+
+// CIDRAccess represents the information needed to ensure proper access to the named LoadBalancer
+// TODO: Move this into pkg/client
+type CIDRAccess struct {
+	LoadBalancer         *LoadBalancer     // For what LoadBalancer does these CIDR restrictions apply?
+	SecurityGroupName    string            // What should the Security Group be called?
+	SecurityGroupVPCName string            // To what VPC should the Security Group be attached?
+	Tags                 map[string]string // Tags to apply to the Security Group and (non-LoadBalancer) related assets?
 }
 
 // Reconcile will ensure that the rh-api management api endpoint is created and ready.
 // Rough Steps:
-// 1. Create Service
-// 2. Add DNS CNAME from rh-api to the ELB created by AWS provider
-// 3. Ready for work (Ready)
+// 1. Create AWS ELB (CreatingLoadBalancer)
+// 2. Create Security Group with allowed CIDR blocks (UpdatingCIDRAllownaces)
+// 3. Add master Node EC2 instances to the load balancer as listeners (6443/TCP) (UpdatingLoadBalancerListeners)
+// 4. Update APIServer object to add a record for the rh-api endpoint (UpdatingAPIServer)
+// 5. Ready for work (Ready)
 func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	reqLogger.Info("Reconciling APIScheme")
 
 	// Fetch the APIScheme instance
 	instance := &cloudingressv1alpha1.APIScheme{}
@@ -112,39 +127,12 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, nil
 	}
 
-	// Does the Service exist already?
-	found := &corev1.Service{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.ManagementAPIServerIngress.DNSName, Namespace: "openshift-kube-apiserver"}, found)
+	ownerTags, err := utils.AWSOwnerTag(r.client)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// need to create it
-			dep := r.newServiceFor(instance)
-			err = r.client.Create(context.TODO(), dep)
-			if err != nil {
-				reqLogger.Error(err, "Failure to create new Service")
-				return reconcile.Result{}, err
-			}
-			// Reconcile again to get the new Service and give AWS time to create the ELB
-			reqLogger.Info("Service was just created, so let's try to requeue to set it up")
-			return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
-		} else if err != nil {
-			reqLogger.Error(err, "Couldn't get the Service")
-			return reconcile.Result{}, err
-		}
-	}
-	// Reconcile the access list in the Service
-	if !sliceEquals(found.Spec.LoadBalancerSourceRanges, instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks) {
-		reqLogger.Info(fmt.Sprintf("Mismatch svc %s != %s\n", found.Spec.LoadBalancerSourceRanges, instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks))
-		reqLogger.Info(fmt.Sprintf("Mismatch between %s/service/%s LoadBalancerSourceRanges and AllowedCIDRBlocks. Updating...", found.GetNamespace(), found.GetName()))
-		found.Spec.LoadBalancerSourceRanges = instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks
-		err = r.client.Update(context.TODO(), found)
-		if err != nil {
-			reqLogger.Error(err, fmt.Sprintf("Failed to update the %s/service/%s LoadBalancerSourceRanges", found.GetNamespace(), found.GetName()))
-			return reconcile.Result{}, err
-		}
-		// let's re-queue just in case
-		reqLogger.Info("Requeuing after svc update")
-		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		reqLogger.Error(err, "Couldn't get the cluster owner tags")
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't get the cluster owner tags", cloudingressv1alpha1.ConditionError)
+		r.client.Status().Update(context.TODO(), instance)
+		return reconcile.Result{}, err
 	}
 
 	region, err := utils.GetClusterRegion(r.client)
@@ -154,6 +142,10 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
 	}
+
+	reqLogger.Info(fmt.Sprintf("Region: %s, Owner tags: +%v", region, ownerTags))
+	// We expect this secret to exist in the same namespace Account CR's are created
+	// TODO: Get the region of the cluster
 	if awsClient == nil {
 		awsClient, err = awsclient.GetAWSClient(r.client, awsclient.NewAwsClientInput{
 			SecretName: config.AWSSecretName,
@@ -167,6 +159,35 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
 	}
+	// Get both public and private subnet names for master Machines
+	// Note: master Machines have only one listed (private one) in their sepc, but
+	// this returns both public and private. We need the public one.
+	subnets, err := utils.GetMasterNodeSubnets(r.client)
+	if err != nil {
+		reqLogger.Error(err, "Couldn't get the subnets used by master nodes")
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't get the cluster's subnets", cloudingressv1alpha1.ConditionError)
+		r.client.Status().Update(context.TODO(), instance)
+		return reconcile.Result{}, err
+	}
+	// Turn the public subnet name into a subnet ID
+	subnetIDs, err := awsClient.SubnetNameToSubnetIDLookup([]string{subnets["public"]})
+	if err != nil {
+		reqLogger.Error(err, "Couldn't turn subnet names into subnet IDs")
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't turn subnet names into subnet IDs", cloudingressv1alpha1.ConditionError)
+		r.client.Status().Update(context.TODO(), instance)
+		return reconcile.Result{}, err
+	}
+	if len(subnetIDs) == 0 {
+		if err != nil {
+			reqLogger.Error(err, "Zero length subnets")
+		} else {
+			reqLogger.Info("Zero length subnets, but no error set.")
+			err = fmt.Errorf("Zero length subnets")
+		}
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't get the cluster's subnets", cloudingressv1alpha1.ConditionError)
+		r.client.Status().Update(context.TODO(), instance)
+		return reconcile.Result{}, err
+	}
 
 	clusterBaseDomain, err := utils.GetClusterBaseDomain(r.client)
 	if err != nil {
@@ -175,77 +196,132 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
 	}
-	// Get the ELB-to-be's name from Service's UID
-	elbName := strings.ReplaceAll("a"+string(found.ObjectMeta.UID), "-", "")
-	if len(elbName) > 32 {
-		// truncate to 32 characters
-		elbName = elbName[0:32]
-	}
-
-	exists, elb, err := awsClient.DoesELBExist(elbName)
+	masterNodeInstances, err := utils.GetClusterMasterInstancesIDs(r.client)
 	if err != nil {
-		reqLogger.Error(err, "Couldn't get ELB info from AWS. Is it not ready yet?")
-		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't get ELB info from AWS. Is it not ready yet?", cloudingressv1alpha1.ConditionError)
+		reqLogger.Error(err, "Couldn't detect the AWS instances for master nodes")
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't find the cluster's AWS instances for master nodes", cloudingressv1alpha1.ConditionError)
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
 	}
-	if !exists {
-		// It isn't bad that it doesn't exist, if there's no error, so re-queue
-		reqLogger.Info("AWS ELB isn't ready yet. Requeueing.")
-		SetAPISchemeStatus(instance, "Couldn't reconcile", "AWS ELB isn't not ready yet.", cloudingressv1alpha1.ConditionError)
+
+	// In theory this could return more than one VPC for master nodes. That would be
+	// odd since the security group is associated with a single VPC.
+	vpcs, err := awsClient.SubnetIDToVPCLookup(subnetIDs)
+	if err != nil {
+		reqLogger.Error(err, "Couldn't get the VPC in use by master nodes")
+		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't get the VPC id for master nodes", cloudingressv1alpha1.ConditionError)
 		r.client.Status().Update(context.TODO(), instance)
-		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, err
+	}
+	if len(vpcs) > 1 {
+		reqLogger.Info(fmt.Sprintf("Multiple VPCs detected for master nodes. Using %s for security group", vpcs[0]))
 	}
 	lb := &LoadBalancer{
-		EndpointName: instance.Spec.ManagementAPIServerIngress.DNSName,
-		BaseDomain:   clusterBaseDomain,
+		EndpointName:     instance.Spec.ManagementAPIServerIngress.DNSName,
+		Subnets:          subnetIDs,
+		Tags:             ownerTags,
+		MachineInstances: masterNodeInstances,
+		BaseDomain:       clusterBaseDomain,
 	}
-
-	err = ensureDNSRecord(awsClient, lb, elb)
+	cidrAccess := &CIDRAccess{
+		LoadBalancer:         lb,
+		SecurityGroupName:    config.AdminAPISecurityGroupName,
+		SecurityGroupVPCName: vpcs[0],
+		Tags:                 ownerTags,
+	}
+	// Now try to make sure all the things for Admin API are present in AWS
+	err = ensureAdminAPIEndpoint(instance, awsClient, lb, cidrAccess)
 	if err != nil {
 		reqLogger.Error(err, "Couldn't ensure the admin API endpoint")
 		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't ensure the admin API endpoint: "+err.Error(), cloudingressv1alpha1.ConditionError)
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
-
 	}
 
 	SetAPISchemeStatus(instance, "Success", "Admin API Endpoint created", cloudingressv1alpha1.ConditionReady)
 	r.client.Status().Update(context.TODO(), instance)
-	return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
+
+	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileAPIScheme) newServiceFor(instance *cloudingressv1alpha1.APIScheme) *corev1.Service {
-	labels := map[string]string{
-		"app":          "cloud-ingress-operator-" + instance.Spec.ManagementAPIServerIngress.DNSName,
-		"apischeme_cr": instance.GetName(),
+func ensureCloudLoadBalancer(awsAPI awsclient.Client, lb *LoadBalancer) (*awsclient.AWSLoadBalancer, error) {
+	var awsObj *awsclient.AWSLoadBalancer
+	found := false
+	var err error
+	for i := 1; i <= config.MaxAPIRetries; i++ {
+		found, awsObj, err = awsAPI.DoesELBExist(lb.EndpointName)
+		if err != nil {
+			log.Info("Couldn't determine if the Admin API ELB exists due to error: " + err.Error())
+			if i == config.MaxAPIRetries {
+				log.Info("Out of retries")
+				return nil, err
+			}
+			log.Info(fmt.Sprintf("Sleeping %d seconds before retrying...", i))
+			time.Sleep(time.Duration(i) * time.Second)
+		} else {
+			// We have a successful response from the API
+			break
+		}
 	}
-	selector := map[string]string{
-		"apiserver": "true",
-		"app":       "openshift-kube-apiserver",
+	if found {
+		log.Info(fmt.Sprintf("ELB exists for Admin API in DNS zone %s with DNS name %s", awsObj.DNSZoneId, awsObj.DNSName))
+	} else {
+		log.Info("Need to create ELB for Admin API")
+		for i := 1; i <= config.MaxAPIRetries; i++ {
+			awsObj, err = awsAPI.CreateClassicELB(lb.EndpointName, lb.Subnets, 6443, lb.Tags)
+			if err != nil {
+				if i == config.MaxAPIRetries {
+					log.Info("Out of retries")
+					return nil, err
+				}
+				log.Info(fmt.Sprintf("Sleeping %d seconds before retrying...", i))
+				time.Sleep(time.Duration(i) * time.Second)
+			} else {
+				log.Info(fmt.Sprintf("Created ELB for Admin API in DNS zone %s with DNS name %s", awsObj.DNSZoneId, awsObj.DNSName))
+				break
+			}
+		}
 	}
-	// Note: This owner reference should nbnot be expected to work
-	//ref := metav1.NewControllerRef(instance, instance.GetObjectKind().GroupVersionKind())
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Spec.ManagementAPIServerIngress.DNSName,
-			Namespace: "openshift-kube-apiserver",
-			Labels:    labels,
-			//OwnerReferences: []metav1.OwnerReference{*ref},
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Protocol:   "TCP",
-					Port:       6443,
-					TargetPort: intstr.FromInt(6443),
-				},
-			},
-			Selector:                 selector,
-			Type:                     corev1.ServiceTypeLoadBalancer,
-			LoadBalancerSourceRanges: instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks,
-		},
+	return awsObj, nil
+}
+
+func ensureCIDRAccess(crObject *cloudingressv1alpha1.APIScheme, awsAPI awsclient.Client, cidrAccess *CIDRAccess) error {
+	for i := 1; i <= config.MaxAPIRetries; i++ {
+
+		err := awsAPI.EnsureCIDRAccess(cidrAccess.LoadBalancer.EndpointName, cidrAccess.SecurityGroupName, cidrAccess.SecurityGroupVPCName, crObject.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks, cidrAccess.Tags)
+		if err != nil {
+			log.Info("Error ensuring CIDR access for the security group: " + err.Error())
+			if i == config.MaxAPIRetries {
+				log.Info("Out of retries")
+				return err
+			}
+			log.Info(fmt.Sprintf("Sleeping %d seconds before retrying...", i))
+			time.Sleep(time.Duration(i) * time.Second)
+		} else {
+			log.Info("Security Group CIDR access ensured")
+			break
+		}
 	}
+	return nil
+}
+
+func ensureLoadBalancerInstances(awsAPI awsclient.Client, lb *LoadBalancer) error {
+	for i := 1; i <= config.MaxAPIRetries; i++ {
+		err := awsAPI.AddLoadBalancerInstances(lb.EndpointName, lb.MachineInstances)
+		if err != nil {
+			log.Info(fmt.Sprintf("Couldn't add instances %s to ELB %s: %s", lb.MachineInstances, lb.EndpointName, err.Error()))
+			if i == config.MaxAPIRetries {
+				log.Info("Out of retries")
+				return err
+			}
+			log.Info(fmt.Sprintf("Sleeping %d seconds before retrying...", i))
+			time.Sleep(time.Duration(i) * time.Second)
+		} else {
+			log.Info(fmt.Sprintf("Added instances %s to ELB", lb.MachineInstances))
+			break
+		}
+	}
+	return nil
 }
 
 func ensureDNSRecord(awsAPI awsclient.Client, lb *LoadBalancer, awsObj *awsclient.AWSLoadBalancer) error {
@@ -288,6 +364,121 @@ func ensureDNSRecord(awsAPI awsclient.Client, lb *LoadBalancer, awsObj *awsclien
 	return nil
 }
 
+// ensureAdminAPIEndpoint will ensure the Admin API endpoint exists. Returns any error
+// This function is idempotent
+func ensureAdminAPIEndpoint(crObject *cloudingressv1alpha1.APIScheme, awsAPI awsclient.Client, lb *LoadBalancer, cidrAccess *CIDRAccess) error {
+
+	// First, let's ensure an ELB exists
+	awsObj, err := ensureCloudLoadBalancer(awsAPI, lb)
+	if err != nil {
+		// This is actually fatal due to the retries in ensureCloudLoadBalancer
+		return err
+	}
+	// Now, ensure CIDR access
+	err = ensureCIDRAccess(crObject, awsAPI, cidrAccess)
+	if err != nil {
+		// This is actually fatal
+		return err
+	}
+	// Add the "master" instances are attached to the ELB
+	err = ensureLoadBalancerInstances(awsAPI, lb)
+	if err != nil {
+		// This is actually fatal
+		return err
+	}
+	// Public and Private zones
+	err = ensureDNSRecord(awsAPI, lb, awsObj)
+	if err != nil {
+		// This is actually fatal
+		return err
+	}
+	// Finally, ensure the DNS name is present in the zone
+	return nil
+}
+
+// addAdminAPIToApiServerObject will add the +domainName+ to the
+// ApiServer/cluster object for the admin api endpoint
+// Two ways to do this:
+// 1. Re-use the existing certificate, but add a new hostname for the apiserver
+// to listen on
+// 2. Add a new TLS certificate and hostname
+// We will use option 1 and trust that the existing TLS cert has an entry for
+// +domainName+
+// Option 1 will look like this:
+//
+// apiVersion: config.openshift.io/v1
+// kind: APIServer
+// metadata:
+//   name: cluster
+// spec:
+//   clientCA:
+//     name: ""
+//   servingCerts:
+//     defaultServingCertificate:
+//       name: ""
+//     namedCertificates:
+//     - names:
+//       - api.<cluster-domain>
+//       - rh-adpi.<cluster-domain>  <-- Add this
+//       servingCertificate:
+//         name: <cluster-name>-primary-cert-bundle-secret
+//
+// For completeness, option 2 looks like
+//
+// apiVersion: config.openshift.io/v1
+// kind: APIServer
+// metadata:
+//   name: cluster
+// spec:
+//   clientCA:
+//     name: ""
+//   servingCerts:
+//     defaultServingCertificate:
+//       name: ""
+//     namedCertificates:
+//     - names:
+//       - api.<cluster-domain>
+//       servingCertificate:
+//         name: <cluster-name>-primary-cert-bundle-secret
+//     - names: <-- Add this
+//       - rh-api.<cluster-domain>
+//       servingCertificate:
+//         name: rh-api-endpoint-cert-bundle-secret <-- openshift-config namespace
+func (r *ReconcileAPIScheme) addAdminAPIToAPIServerObject(clusterBaseDomainName string, instance *cloudingressv1alpha1.APIScheme) error {
+	// Where the new endpoint is listening at
+	adminEndpoint := instance.Spec.ManagementAPIServerIngress.DNSName + "." + clusterBaseDomainName
+	api := &configv1.APIServer{}
+	ns := types.NamespacedName{
+		Namespace: "",
+		Name:      "cluster",
+	}
+	err := r.client.Get(context.TODO(), ns, api)
+	if err != nil {
+		return err
+	}
+	// FIXME: Check so there's no duplicate addresses added
+	needToAdd := false
+	for i, namedCerts := range api.Spec.ServingCerts.NamedCertificates {
+		for _, name := range namedCerts.Names {
+			if name == adminEndpoint {
+				// No work to do
+				log.Info(fmt.Sprintf("No need to update APIServer/cluster: %s already present", adminEndpoint))
+				return nil
+			} else if name == "api."+clusterBaseDomainName {
+				// This is where our primary API endpoint is, and where we need to add it.
+				// "This" meaning the particular namedCerts as in spec.servingCerts.namedCertificates[]
+				needToAdd = true
+			}
+		}
+		if needToAdd {
+			// By here, we know we have to append the name.
+			api.Spec.ServingCerts.NamedCertificates[i].Names = append(api.Spec.ServingCerts.NamedCertificates[i].Names, adminEndpoint)
+			return r.client.Update(context.TODO(), api)
+		}
+	}
+	return nil
+}
+
 // SetAPISchemeStatus will set the status on the APISscheme object with a human message, as in an error situation
 func SetAPISchemeStatus(crObject *cloudingressv1alpha1.APIScheme, reason, message string, ctype cloudingressv1alpha1.APISchemeConditionType) {
 	crObject.Status.Conditions = utils.SetAPISchemeCondition(
@@ -298,17 +489,4 @@ func SetAPISchemeStatus(crObject *cloudingressv1alpha1.APIScheme, reason, messag
 		message,
 		utils.UpdateConditionNever)
 	crObject.Status.State = ctype
-}
-
-func sliceEquals(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for i := 0; i < len(left); i++ {
-		if left[i] != right[i] {
-			fmt.Printf("Mismatch %s != %s\n", left[i], right[i])
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/controller/apischeme/apischeme_controller_test.go
+++ b/pkg/controller/apischeme/apischeme_controller_test.go
@@ -1,14 +1,98 @@
 package apischeme
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
 
+	configv1 "github.com/openshift/api/config/v1"
 	utils "github.com/openshift/cloud-ingress-operator/pkg/controller/utils"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+func TestMasterNodeSubnets(t *testing.T) {
+	tests := []struct {
+		region       string
+		az           string
+		clustername  string
+		cidrs        []string
+		endpointName string
+		masterCount  int
+		apiEndpoint  string
+
+		mockSubnetIDInput   []string // name to id lookup input
+		mockSubnetIDOutput0 []string // name to id lookup output
+		mockSubnetIDOutput1 error    // name to id lookup error
+	}{
+		{
+			region:       testutils.DefaultRegionName,
+			az:           testutils.DefaultAzName,
+			clustername:  "test1",
+			cidrs:        []string{"0.0.0.0/0"},
+			endpointName: "rh-api",
+			masterCount:  3,
+			apiEndpoint:  testutils.DefaultAPIEndpoint,
+
+			mockSubnetIDInput:   []string{"test1-public-" + testutils.DefaultAzName},
+			mockSubnetIDOutput0: []string{"subnet-12345"},
+			mockSubnetIDOutput1: nil,
+		},
+		{
+			region:       testutils.DefaultRegionName,
+			az:           testutils.DefaultAzName,
+			clustername:  "test2",
+			cidrs:        []string{"0.0.0.0/0"},
+			endpointName: "rh-api",
+			masterCount:  3,
+			apiEndpoint:  testutils.DefaultAPIEndpoint,
+
+			mockSubnetIDInput:   []string{"test2-public-" + testutils.DefaultAzName},
+			mockSubnetIDOutput0: []string{"subnet-abcdef"},
+			mockSubnetIDOutput1: nil,
+		},
+	}
+
+	for testNumber, test := range tests {
+		aObj := testutils.CreateAPISchemeObject(test.endpointName, true, test.cidrs)
+		masterNames := make([]string, test.masterCount)
+		for i := 0; i < test.masterCount; i++ {
+			masterNames[i] = fmt.Sprintf("master-%d", i)
+		}
+		machineList, _ := testutils.CreateMachineObjectList(masterNames, test.clustername, "master", test.region, test.az)
+		infraObj := testutils.CreateInfraObject(test.clustername, test.apiEndpoint, test.apiEndpoint, test.region)
+		objs := []runtime.Object{aObj, infraObj, machineList}
+		mocks := testutils.NewTestMock(t, objs)
+
+		expectedPublicSubnetName := fmt.Sprintf("%s-public-%s", test.clustername, test.az)
+		res, err := utils.GetMasterNodeSubnets(mocks.FakeKubeClient)
+		if err != nil {
+			t.Fatalf("Test %d Couldn't get the master node subnets: %v", testNumber, err)
+		}
+		if res["public"] != expectedPublicSubnetName {
+			t.Fatalf("Subnet mismatch. Got %s, expected %s", res["public"], expectedPublicSubnetName)
+		}
+		s := []string{res["public"]}
+		// now safe to mock the name -> id lookup
+		mocks.MockAws.EXPECT().SubnetNameToSubnetIDLookup(test.mockSubnetIDInput).AnyTimes().Return(test.mockSubnetIDOutput0, test.mockSubnetIDOutput1)
+
+		subnets, err := mocks.MockAws.SubnetNameToSubnetIDLookup(s)
+		if err != nil {
+			t.Fatalf("Couldn't lookup subnet IDs from name: %v", err)
+		}
+
+		if len(subnets) != len(test.mockSubnetIDInput) {
+			t.Fatalf("Test %d Wrong number of subnets back. Got %d, expected %d", testNumber, len(subnets), 1)
+		}
+		for i := range subnets {
+			if subnets[i] != test.mockSubnetIDOutput0[i] {
+				t.Fatalf("Wrong subnet ID back for public. Got %s, expected %s", subnets[i], test.mockSubnetIDOutput0[i])
+			}
+		}
+	}
+}
 
 func TestClusterBaseDomain(t *testing.T) {
 	aObj := testutils.CreateAPISchemeObject("rh-api", true, []string{"0.0.0.0/0"})
@@ -29,3 +113,132 @@ func TestClusterBaseDomain(t *testing.T) {
 		t.Fatalf("Base domain mismatch. Expected %s, got %s", "unit.test", base)
 	}
 }
+
+func TestMasterInstanceIds(t *testing.T) {
+	aObj := testutils.CreateAPISchemeObject("rh-api", true, []string{"0.0.0.0/0"})
+	masterNames := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		masterNames[i] = fmt.Sprintf("master-%d", i)
+	}
+	machineList, _ := testutils.CreateMachineObjectList(masterNames, "ids", "master", testutils.DefaultRegionName, testutils.DefaultAzName)
+	infraObj := testutils.CreateInfraObject("ids", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
+	objs := []runtime.Object{aObj, infraObj, machineList}
+	mocks := testutils.NewTestMock(t, objs)
+
+	ids, err := utils.GetClusterMasterInstancesIDs(mocks.FakeKubeClient)
+	if err != nil {
+		t.Fatalf("Could not get cluster base domain name: %v", err)
+	}
+	if len(ids) != len(masterNames) {
+		t.Fatalf("Master Instance ID length mismatch. Expected %d, got %d", len(masterNames), len(ids))
+	}
+	for _, id := range ids {
+		if id[0] != 'i' {
+			t.Fatalf("Expected AWS instance ID to begin with i, got %s", string(id[0]))
+		}
+	}
+}
+
+// TestAddAdminToAPIServerObject tests one of the two possible ways to add
+// information to the APIServer object. In the controller proper, we use only
+// "option 1" ("option 2" is briefly documented in the controller, with option
+// 1's notes)
+func TestAddAdminToAPIServerObject(t *testing.T) {
+	aObj := testutils.CreateAPISchemeObject("rh-api", true, []string{"0.0.0.0/0"})
+	masterNames := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		masterNames[i] = fmt.Sprintf("master-%d", i)
+	}
+	apiserver := testutils.CreateAPIServerObject("apiservertest", testutils.DefaultClusterDomain)
+	machineList, _ := testutils.CreateMachineObjectList(masterNames, "ids", "master", testutils.DefaultRegionName, testutils.DefaultAzName)
+	infraObj := testutils.CreateInfraObject("ids", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
+	objs := []runtime.Object{aObj, infraObj, machineList, apiserver}
+	mocks := testutils.NewTestMock(t, objs)
+	r := &ReconcileAPIScheme{client: mocks.FakeKubeClient, scheme: mocks.Scheme}
+	domain, err := utils.GetClusterBaseDomain(mocks.FakeKubeClient)
+	if err != nil {
+		t.Fatalf("Couldn't get cluster base domain for test %v", err)
+	}
+	err = r.addAdminAPIToAPIServerObject(domain, aObj)
+	if err != nil {
+		t.Fatalf("Couldn't update APIServer object %v", err)
+	}
+	api := &configv1.APIServer{}
+	ns := types.NamespacedName{
+		Namespace: "",
+		Name:      "cluster",
+	}
+	err = r.client.Get(context.TODO(), ns, api)
+	if err != nil {
+		t.Fatalf("Couldn't re-read the APIServer object %v", err)
+	}
+	expected := fmt.Sprintf("%s.%s", aObj.Spec.ManagementAPIServerIngress.DNSName, domain)
+	match := false
+	for _, cert := range api.Spec.ServingCerts.NamedCertificates {
+		for _, name := range cert.Names {
+			if name == expected {
+				match = true
+			}
+		}
+	}
+	if !match {
+		t.Fatalf("Never detected cert %s in named certs %+v", expected, api.Spec.ServingCerts.NamedCertificates)
+	}
+}
+
+/*
+ * Note: Having issues with this test where the Mock aws client isn't working
+ * with the assignment, as Go claims it isn't implementing the entire Client
+ * interface. Commented this out til it can be explored more.
+func TestCreateApiScheme(t *testing.T) {
+	tests := []struct {
+		region              string
+		az                  string
+		clustername         string
+		cidrs               []string
+		endpointName        string
+		masterCount         int
+		apiEndpoint         string
+		mockSubnetIDInput   []string
+		mockSubnetIDOutput0 []string
+		mockSubnetIDOutput1 error
+	}{
+		{
+			region:       testutils.DefaultRegionName,
+			az:           testutils.DefaultAzName,
+			clustername:  "test1",
+			cidrs:        []string{"0.0.0.0/0"},
+			endpointName: "rh-api",
+			masterCount:  3,
+			apiEndpoint:  testutils.DefaultAPIEndpoint,
+		},
+	}
+	for _, test := range tests {
+		aObj := makeAPISchemeObj(test.endpointName, true, test.cidrs)
+		masterNames := make([]string, test.masterCount)
+		for i := 0; i < test.masterCount; i++ {
+			masterNames[i] = fmt.Sprintf("master-%d", i)
+		}
+		machineList, _ := createMachineObjectList(masterNames, test.clustername, "master", test.region, test.az)
+		infraObj := infraObj(test.clustername, test.apiEndpoint, test.apiEndpoint, test.region)
+		objs := []runtime.Object{aObj, infraObj, machineList}
+		mocks := setupTests(t, objs)
+		awsClient = mocks.mockAws
+
+		r := &ReconcileAPIScheme{client: mocks.fakeKubeClient, scheme: mocks.scheme}
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      test.endpointName,
+				Namespace: config.OperatorNamespace,
+			},
+		}
+
+		res, err := r.Reconcile(req)
+		if err != nil {
+			t.Fatalf("reconcile: (%v)", err)
+		}
+		fmt.Printf("res = %+v\n", res)
+	}
+
+}
+*/


### PR DESCRIPTION
This reverts #63 

The reason for the revert is that it seems like there's strange behaviour with some clusters not getting the rh-api Service, and sometimes they do get them. Let's revert this so Sam can carry on with #69. Once his PR is merged and promoted, we can revisit #63 (with improved logging and such) to get to the bottom of this issue.