### PR TITLE
OSD-3564: Remove extra log statements & Spec is mandatory

### DIFF
--- a/deploy/crds/cloudingress.managed.openshift.io_apischemes_crd.yaml
+++ b/deploy/crds/cloudingress.managed.openshift.io_apischemes_crd.yaml
@@ -19,12 +19,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -38,12 +38,17 @@ spec:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               properties:
                 allowedCIDRBlocks:
+                  description: AllowedCIDRBlocks is the list of CIDR blocks that should
+                    be allowed to access the management API
                   items:
                     type: string
                   type: array
                 dnsName:
+                  description: DNSName is the name that should be used for DNS of
+                    the management API, eg rh-api
                   type: string
                 enabled:
+                  description: Enabled to create the Management API endpoint or not.
                   type: boolean
               required:
               - allowedCIDRBlocks
@@ -62,7 +67,50 @@ spec:
                 code after modifying this file Add custom validation using kubebuilder
                 tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
+            conditions:
+              items:
+                description: APISchemeCondition is the history of transitions
+                properties:
+                  allowedCIDRBlocks:
+                    description: AllowedCIDRBlocks currently allowed (as of the last
+                      successful Security Group update)
+                    items:
+                      type: string
+                    type: array
+                  lastProbeTime:
+                    description: LastProbeTime last time probed
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime Last change to status
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is an English text
+                    type: string
+                  reason:
+                    description: Reason is why we're making this status change
+                    type: string
+                  status:
+                    description: Status
+                    type: string
+                  type:
+                    description: Type is the type of condition
+                    type: string
+                required:
+                - lastProbeTime
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                type: object
+              type: array
+            state:
+              description: APISchemeConditionType - APISchemeConditionType
+              type: string
           type: object
+      required:
+      - spec
       type: object
   version: v1alpha1
   versions:

--- a/deploy/crds/cloudingress.managed.openshift.io_publishingstrategies_crd.yaml
+++ b/deploy/crds/cloudingress.managed.openshift.io_publishingstrategies_crd.yaml
@@ -128,6 +128,8 @@ spec:
         status:
           description: PublishingStrategyStatus defines the observed state of PublishingStrategy
           type: object
+      required:
+      - spec
       type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/cloudingress/v1alpha1/apischeme_types.go
+++ b/pkg/apis/cloudingress/v1alpha1/apischeme_types.go
@@ -56,7 +56,7 @@ type APIScheme struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   APISchemeSpec   `json:"spec,omitempty"`
+	Spec   APISchemeSpec   `json:"spec"`
 	Status APISchemeStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/cloudingress/v1alpha1/publishingstrategy_types.go
+++ b/pkg/apis/cloudingress/v1alpha1/publishingstrategy_types.go
@@ -63,7 +63,7 @@ type PublishingStrategy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   PublishingStrategySpec   `json:"spec,omitempty"`
+	Spec   PublishingStrategySpec   `json:"spec"`
 	Status PublishingStrategyStatus `json:"status,omitempty"`
 }
 

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -30,12 +30,8 @@ import (
 )
 
 var (
-	// reconcileCount is how many times the Reconcile loop has fired. This
-	// controls how often we log what we're doing therein since it is checking
-	// every minute.
-	reconcileCount = 0
-	log            = logf.Log.WithName("controller_apischeme")
-	awsClient      awsclient.Client
+	log       = logf.Log.WithName("controller_apischeme")
+	awsClient awsclient.Client
 )
 
 /**
@@ -96,10 +92,7 @@ type LoadBalancer struct {
 // 3. Ready for work (Ready)
 func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reconcileCount++
-	if reconcileCount%1000 == 0 {
-		reqLogger.Info("Reconciling APIScheme", "request", request)
-	}
+	reqLogger.Info("Reconciling APIScheme")
 
 	// Fetch the APIScheme instance
 	instance := &cloudingressv1alpha1.APIScheme{}
@@ -121,6 +114,7 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 	// disabled, but that has SERIOUS potential issues with Hive, as it will come to
 	// depend on rh-api.
 	if !instance.Spec.ManagementAPIServerIngress.Enabled {
+		reqLogger.Info("Not enabled", "instance", instance)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -29,8 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_apischeme")
-var awsClient awsclient.Client
+var (
+	// reconcileCount is how many times the Reconcile loop has fired. This
+	// controls how often we log what we're doing therein since it is checking
+	// every minute.
+	reconcileCount = 0
+	log            = logf.Log.WithName("controller_apischeme")
+	awsClient      awsclient.Client
+)
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -90,8 +96,10 @@ type LoadBalancer struct {
 // 3. Ready for work (Ready)
 func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-
-	reqLogger.Info("Reconciling APIScheme", "request", request)
+	reconcileCount++
+	if reconcileCount%1000 == 0 {
+		reqLogger.Info("Reconciling APIScheme", "request", request)
+	}
 
 	// Fetch the APIScheme instance
 	instance := &cloudingressv1alpha1.APIScheme{}
@@ -113,7 +121,6 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 	// disabled, but that has SERIOUS potential issues with Hive, as it will come to
 	// depend on rh-api.
 	if !instance.Spec.ManagementAPIServerIngress.Enabled {
-		reqLogger.Info("APISchme is not enabled.")
 		return reconcile.Result{}, nil
 	}
 
@@ -138,7 +145,6 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 			return reconcile.Result{}, err
 		}
 	}
-	reqLogger.Info("Service was found!", "service", found)
 	// Reconcile the access list in the Service
 	if !sliceEquals(found.Spec.LoadBalancerSourceRanges, instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks) {
 		reqLogger.Info(fmt.Sprintf("Mismatch svc %s != %s\n", found.Spec.LoadBalancerSourceRanges, instance.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks))
@@ -189,7 +195,6 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		elbName = elbName[0:32]
 	}
 
-	reqLogger.Info("Checking to see if the ELB exists in AWS", "elbName", elbName)
 	exists, elb, err := awsClient.DoesELBExist(elbName)
 	if err != nil {
 		reqLogger.Error(err, "Couldn't get ELB info from AWS. Is it not ready yet?")
@@ -208,8 +213,6 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		EndpointName: instance.Spec.ManagementAPIServerIngress.DNSName,
 		BaseDomain:   clusterBaseDomain,
 	}
-
-	reqLogger.Info("Making sure the DNS entry exists", "lb", lb, "elb", elb)
 
 	err = ensureDNSRecord(awsClient, lb, elb)
 	if err != nil {


### PR DESCRIPTION
This change is wider scoped than only APIScheme because it also makes
Spec mandatory for PublishingStrategy CRDs. We always want these to be
mandatory since we need them present to do anything useful in their
respective controllers.

In order to keep tabs on some of what is going on in the APIScheme
controller, there is a new variable to control when to print it's
activities. It will log activity every 1000 reconcilations (every ~1000
minutes), just so we have some other kind of heartbeat.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>