### PR TITLE
Pin operator to run on infra nodes

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -14,6 +14,20 @@ spec:
         name: cloud-ingress-operator
     spec:
       serviceAccountName: cloud-ingress-operator
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io"
+                operator: In
+                values: 
+                  - infra
+      tolerations:
+      - operator: Equal
+        key: node-role.kubernetes.io
+        value: infra
+        effect: PreferNoSchedule
       containers:
         - name: cloud-ingress-operator
           # Replace this with the built image name

--- a/deploy/60_cloud-ingress-operator-registry.CatalogSource.yaml
+++ b/deploy/60_cloud-ingress-operator-registry.CatalogSource.yaml
@@ -10,16 +10,18 @@ spec:
   image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
   affinity:
     nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: node-role.kubernetes.io/infra
-            operator: Exists
-        weight: 1
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: "node-role.kubernetes.io"
+            operator: In
+            values: 
+              - infra
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/infra
-    operator: Exists
+  - operator: Equal
+    key: node-role.kubernetes.io
+    value: infra
+    effect: PreferNoSchedule
   displayName: ${REPO_NAME}
   icon:
     base64data: ''

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -302,16 +302,18 @@ objects:
         image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
         affinity:
           nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io
+                  operator: In
+                  values:
+                  - infra
         tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/infra
-          operator: Exists
+        - operator: Equal
+          key: node-role.kubernetes.io
+          value: infra
+          effect: PreferNoSchedule
         displayName: ${REPO_NAME}
         icon:
           base64data: ''


### PR DESCRIPTION
Per OHSS-3697
The operator is currently running on customer worker nodes. This PR changes that and makes the operator run on infra nodes only. 

We are switching from `preferredDuringSchedulingIgnoredDuringExecution` to `requiredDuringSchedulingIgnoredDuringExecution` because with `preferred` the scheduler will allow the workload to be run on any node, a "soft" rule, while `required` is a "hard" rule, making it a requirement. For more information on this check out OHSS-2971 or  https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/