### PR TITLE
Add debug logs

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -139,6 +139,12 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 		}
 	}
 
+	// ----------------------------TODO: remove these debug logs afterwards --------------------------------------
+	log.Info(fmt.Sprintf("initial ingresscontroller list: %v", ingressControllerList.Items))
+	log.Info(fmt.Sprintf("appingress on publishingstrategy CR: %v", instance.Spec.ApplicationIngress))
+	log.Info(fmt.Sprintf("ingress to reconcile: %v", ingressNotOnCluster))
+	// -----------------------------------------------------------------------------------------------------------
+
 	for _, appingress := range ingressNotOnCluster {
 		newCertificate := &corev1.LocalObjectReference{
 			Name: appingress.Certificate.Name,

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -140,9 +140,9 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 	}
 
 	// ----------------------------TODO: remove these debug logs afterwards --------------------------------------
-	log.Info(fmt.Sprintf("initial ingresscontroller list: %v", ingressControllerList.Items))
-	log.Info(fmt.Sprintf("appingress on publishingstrategy CR: %v", instance.Spec.ApplicationIngress))
-	log.Info(fmt.Sprintf("ingress to reconcile: %v", ingressNotOnCluster))
+	log.Info(fmt.Sprintf("initial ingresscontroller list: %+v", ingressControllerList.Items))
+	log.Info(fmt.Sprintf("appingress on publishingstrategy CR: %+v", instance.Spec.ApplicationIngress))
+	log.Info(fmt.Sprintf("ingress to reconcile: %+v", ingressNotOnCluster))
 	// -----------------------------------------------------------------------------------------------------------
 
 	for _, appingress := range ingressNotOnCluster {


### PR DESCRIPTION
I'm primarily concerned with 
1. What the initial list of ingresscontroller looks like on cluster
2. What we have in the publshingstrategy
3. The list of the difference. aka what we have in publishingstrategy that is NOT on cluster. - these are the ones that the reconcile should action on.