### PR TITLE
Move sleep statement

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -123,10 +123,6 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// wait 60 seconds for deletion to be completed
-	log.Info("waited 60 seconds for necessary ingresscontroller deletions")
-	time.Sleep(time.Duration(60) * time.Second)
-
 	// create list of applicationIngress
 	var ingressNotOnCluster []cloudingressv1alpha1.ApplicationIngress
 
@@ -377,6 +373,9 @@ func (r *ReconcilePublishingStrategy) deleteIngressWithAnnotation(appIngressList
 				log.Error(err, "Failed to delete ingresscontroller")
 				return err
 			}
+			// wait 60 seconds for deletion to be completed
+			log.Info("waited 60 seconds for necessary ingresscontroller deletions")
+			time.Sleep(time.Duration(60) * time.Second)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently there is a sleep statement in the PublishingStrategy controller that gets hit every reconcile trigger while waiting for an ingresscontroller deletion . This PR is to move that sleep statement to only activate when it needs to (eg. there is an actual deletion taking place)

This issue is being tracked at OSD-4327