### PR TITLE
sshd: Set a 10 minute idle timeout on the LB service

### DIFF
--- a/pkg/controller/sshd/sshd_controller.go
+++ b/pkg/controller/sshd/sshd_controller.go
@@ -468,6 +468,9 @@ func newSSHDService(cr *cloudingressv1alpha1.SSHD) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
+			Annotations: map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "600",
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{


### PR DESCRIPTION
This gives more time for `sshd` to send a client alive message, which should keep the connection open.

Without this, the SSH proxy connection was dropping every minute since the default ELB idle timeout is 60 seconds.  With the longer timeout, and `sshd` configured to send a client alive message within that timeout, I was able to keep a connection open overnight as a test.