### PR TITLE
Make enableManagementAPIServerIngress variable

### DIFF
--- a/deploy/90_rh-api.APIScheme.yaml
+++ b/deploy/90_rh-api.APIScheme.yaml
@@ -7,6 +7,6 @@ metadata:
     allowedCIDRBlocks: "${ALLOWED_CIDR_BLOCKS}"
 spec:
   managementAPIServerIngress:
-    enabled: true
+    enabled: "${ENABLE_MANAGEMENT_API_SERVER_INGRESS}"
     dnsName: rh-api
     allowedCIDRBlocks: "${{ALLOWED_CIDR_BLOCKS}}"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -12,6 +12,8 @@ parameters:
   required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
+- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -347,7 +349,7 @@ objects:
           allowedCIDRBlocks: ${ALLOWED_CIDR_BLOCKS}
       spec:
         managementAPIServerIngress:
-          enabled: true
+          enabled: ${ENABLE_MANAGEMENT_API_SERVER_INGRESS}
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
     - apiVersion: cloudingress.managed.openshift.io/v1alpha1

--- a/hack/templates/template.yaml
+++ b/hack/templates/template.yaml
@@ -12,6 +12,8 @@ parameters:
   required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
+- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects: []

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -109,10 +109,12 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		reqLogger.Error(err, "Error reading APIScheme object")
 		return reconcile.Result{}, err
 	}
+
+	// TODO(efried/lisa/lseelye): Add finalizer and check for deletionTimestamp to tear things
+	// down. But that has SERIOUS potential issues with Hive, as it will come to depend on
+	// rh-api.
+
 	// If the management API isn't enabled, we have nothing to do!
-	// TODO (lisa/lseelye): This should call a teardown feature to ensure we have
-	// disabled, but that has SERIOUS potential issues with Hive, as it will come to
-	// depend on rh-api.
 	if !instance.Spec.ManagementAPIServerIngress.Enabled {
 		reqLogger.Info("Not enabled", "instance", instance)
 		return reconcile.Result{}, nil


### PR DESCRIPTION
As part of the solution for the referenced Jira, we want v3 hives to
*not* apply the APIScheme until private-cluster-rhapi-apischeme-updater
has gotten a chance to run. So we're making that a variable, which we'll
set to `false` for v3 hives and `true` for v4 hives in the appsre
pipeline. The private-cluster-rhapi-apischeme-updater will then toggle
it to `true` as it updates the allowedCIDRBlocks.

Prerequisites to this PR:
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8013 sets this new variable to `true` by default and `false` for v3 hive shards.
- https://github.com/openshift/private-cluster-rhapi-apischeme-updater/pull/16 toggles the value to `true` along with updating the CIDR blocks.

Jira: [OHSS-909](https://issues.redhat.com/browse/OHSS-909)