### PR TITLE
sshd: Pin the SSHD pod to a specific image tag

### DIFF
--- a/deploy/90_rh-ssh.SSHD.yaml
+++ b/deploy/90_rh-ssh.SSHD.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   dnsName: rh-ssh
   allowedCIDRBlocks: "${{ALLOWED_CIDR_BLOCKS}}"
-  image: quay.io/app-sre/sre-ssh-proxy
+  image: quay.io/app-sre/sre-ssh-proxy:v44-262ce16

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -359,7 +359,7 @@ objects:
       spec:
         dnsName: rh-ssh
         allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
-        image: quay.io/app-sre/sre-ssh-proxy
+        image: quay.io/app-sre/sre-ssh-proxy:v44-262ce16
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/pkg/controller/sshd/sshd_controller.go
+++ b/pkg/controller/sshd/sshd_controller.go
@@ -393,7 +393,7 @@ func newSSHDDeployment(cr *cloudingressv1alpha1.SSHD, configMapList *corev1.Conf
 		VolumeMounts:             volumeMounts,
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		ImagePullPolicy:          corev1.PullAlways,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
 	}
 
 	return &appsv1.Deployment{


### PR DESCRIPTION
So we're not immediately promoting master commits to production.

This image tag corresponds to the latest automated build:
https://ci.ext.devshift.net/view/sre-ssh-proxy/job/openshift-sre-ssh-proxy-container-gh-build-master/11/

Also, change the `ImagePullPolicy` to `"IfNotPresent"` per https://issues.redhat.com/browse/OSD-4812