### PR TITLE
sshd: Generate host keys and bundle into a secret 

### DIFF
--- a/deploy/90_rh-ssh.SSHD.yaml
+++ b/deploy/90_rh-ssh.SSHD.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   dnsName: rh-ssh
   allowedCIDRBlocks: "${{ALLOWED_CIDR_BLOCKS}}"
-  image: quay.io/app-sre/sre-ssh-proxy:v44-262ce16
+  image: quay.io/app-sre/sre-ssh-proxy:v49-1fde8e5

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.15.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -306,7 +306,7 @@ objects:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
             - preference:
-              matchExpressions:
+                matchExpressions:
                 - key: node-role.kubernetes.io/infra
                   operator: Exists
               weight: 1

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -359,7 +359,7 @@ objects:
       spec:
         dnsName: rh-ssh
         allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
-        image: quay.io/app-sre/sre-ssh-proxy:v44-262ce16
+        image: quay.io/app-sre/sre-ssh-proxy:v49-1fde8e5
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/pkg/controller/sshd/sshd_controller.go
+++ b/pkg/controller/sshd/sshd_controller.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 	"time"
 
+	// For host key generation
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/pkg/awsclient"
 	"github.com/openshift/cloud-ingress-operator/pkg/config"
@@ -21,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,6 +119,7 @@ type ReconcileSSHD struct {
 
 const (
 	authorizedKeysMountPath   = "/var/run/authorized_keys.d"
+	hostKeysMountPath         = "/var/run/ssh"
 	nodeMasterLabel           = "node-role.kubernetes.io/master"
 	reconcileSSHDFinalizerDNS = "dns.cloudingress.managed.openshift.io"
 )
@@ -211,15 +219,47 @@ func (r *ReconcileSSHD) Reconcile(request reconcile.Request) (reconcile.Result, 
 		r.SetSSHDStatusError(instance, "Failed to list config maps with SSH keys", err)
 		return reconcile.Result{}, err
 	}
-	// Sort ConfigMaps by name for the purpose of creating
-	// stable Volume and VolumeMount lists in the Deployment.
-	sort.Slice(configMapList.Items, func(i, j int) bool {
-		return configMapList.Items[i].Name < configMapList.Items[j].Name
-	})
+
+	// Install "host-keys" Secret
+	//
+	// Since host key generation has a random component and is therefore
+	// different each time, only call newSSHDSecret if an existing secret
+	// cannot be found.
+	hostKeysSecret := &corev1.Secret{}
+	secretName := types.NamespacedName{
+		Namespace: instance.Namespace,
+		Name:      instance.Name + "-host-keys",
+	}
+	if err = r.client.Get(context.TODO(), secretName, hostKeysSecret); err != nil {
+		if errors.IsNotFound(err) {
+			// Create a new "host-keys" Secret.
+			r.SetSSHDStatusPending(instance, "Generating host keys")
+			secret, err := newSSHDSecret(secretName.Namespace, secretName.Name)
+			if err != nil {
+				r.SetSSHDStatusError(instance, "Failed to generate host keys", err)
+				return reconcile.Result{}, err
+			}
+			if err := controllerutil.SetControllerReference(instance, secret, r.scheme); err != nil {
+				r.SetSSHDStatusError(instance, "Failed to set secret controller reference", err)
+				return reconcile.Result{}, err
+			}
+			if err = r.client.Create(context.TODO(), secret); err != nil {
+				if errors.IsAlreadyExists(err) {
+					return reconcile.Result{Requeue: true}, nil
+				}
+				r.SetSSHDStatusError(instance, "Failed to create secret", err)
+				return reconcile.Result{}, err
+			}
+			// Get the created secret on the next pass.
+			return reconcile.Result{Requeue: true}, nil
+		} else {
+			return reconcile.Result{}, err
+		}
+	}
 
 	// Install Deployment
 	foundDeployment := &appsv1.Deployment{}
-	deployment := newSSHDDeployment(instance, configMapList)
+	deployment := newSSHDDeployment(instance, configMapList, hostKeysSecret)
 	deploymentName, err := client.ObjectKeyFromObject(deployment)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -355,7 +395,41 @@ func getMatchLabels(cr *cloudingressv1alpha1.SSHD) map[string]string {
 	return map[string]string{"deployment": cr.Name}
 }
 
-func newSSHDDeployment(cr *cloudingressv1alpha1.SSHD, configMapList *corev1.ConfigMapList) *appsv1.Deployment {
+func newSSHDSecret(namespace, name string) (*corev1.Secret, error) {
+	// Generate 4096-bit RSA key
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, err
+	}
+	ssh_host_rsa_key := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rsaKey),
+	})
+
+	// XXX Generate other key types?
+	//     ECDSA:   Easy, fully supported in standard library.
+	//     ED25519: Standard library can generate a private key, but requires an
+	//              external module to create an "OPENSSH PRIVATE KEY" PEM block:
+	//              https://github.com/mikesmitty/edkey
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			// Key also serves as an environment variable name
+			// (uppercased) and must be a valid C_IDENTIFIER.
+			"ssh_host_rsa_key": ssh_host_rsa_key,
+		},
+	}, nil
+}
+
+func newSSHDDeployment(cr *cloudingressv1alpha1.SSHD, configMapList *corev1.ConfigMapList, hostKeysSecret *corev1.Secret) *appsv1.Deployment {
 	// Prefer nil over empty slices to satisfy reflect.DeepEqual.
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -378,6 +452,52 @@ func newSSHDDeployment(cr *cloudingressv1alpha1.SSHD, configMapList *corev1.Conf
 			MountPath: filepath.Join(authorizedKeysMountPath, volumeName),
 		})
 	}
+	// Sort volume slices by name to keep the sequence stable.
+	sort.Slice(volumes, func(i, j int) bool {
+		return volumes[i].Name < volumes[j].Name
+	})
+	sort.Slice(volumeMounts, func(i, j int) bool {
+		return volumeMounts[i].Name < volumeMounts[j].Name
+	})
+
+	volumeName := hostKeysSecret.ObjectMeta.Name
+	volumes = append(volumes, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: hostKeysSecret.ObjectMeta.Name,
+				// Mode needs to satisfy OpenSSH's requirements
+				// for HostKey files: sshd will refuse to use a
+				// file if it is group/world-accessible.
+				// https://man.openbsd.org/sshd_config#HostKey
+				//
+				// For owner permissions, "read" is sufficient
+				// for the container.
+				DefaultMode: pointer.Int32Ptr(0400),
+				Optional:    pointer.BoolPtr(false),
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: hostKeysMountPath,
+	})
+
+	// Add environment variables to help the container configure itself.
+	var env []corev1.EnvVar
+	env = append(env, corev1.EnvVar{
+		Name:  "AUTHORIZED_KEYS_DIR",
+		Value: authorizedKeysMountPath,
+	})
+	for key := range hostKeysSecret.Data {
+		env = append(env, corev1.EnvVar{
+			Name:  strings.ToUpper(key),
+			Value: filepath.Join(hostKeysMountPath, key),
+		})
+	}
+	sort.Slice(env, func(i, j int) bool {
+		return env[i].Name < env[j].Name
+	})
 
 	sshdContainer := corev1.Container{
 		Name:    "sshd",
@@ -390,6 +510,7 @@ func newSSHDDeployment(cr *cloudingressv1alpha1.SSHD, configMapList *corev1.Conf
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
+		Env:                      env,
 		VolumeMounts:             volumeMounts,
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,


### PR DESCRIPTION
Generating only a 4096-bit RSA host key for now.  Not sure if we want other key types as well like ED25519.

Also added environment variables to the pod for various mount points, hoping I can teach the SSHD image to generate an `sshd_config` from a template at startup.