### PR TITLE
Refactor cloudclient

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -9,9 +9,13 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	utils "github.com/openshift/cloud-ingress-operator/pkg/controller/utils"
+	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	awsproviderapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cloud-ingress-operator/pkg/config"
@@ -93,6 +97,78 @@ func (c *Client) setDefaultAPIPrivate(ctx context.Context, kclient client.Client
 	}
 	return nil
 }
+func getInfrastructureObject(kclient client.Client) (*configv1.Infrastructure, error) {
+	infra := &configv1.Infrastructure{}
+	ns := types.NamespacedName{
+		Namespace: "",
+		Name:      "cluster",
+	}
+	err := kclient.Get(context.TODO(), ns, infra)
+	if err != nil {
+		return nil, err
+	}
+	return infra, nil
+}
+
+const masterMachineLabel string = "machine.openshift.io/cluster-api-machine-role"
+
+// GetMasterNodes returns a machineList object whose .Items can be iterated
+// over to perform actions on/with information from each master machine object
+func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
+	machineList := &machineapi.MachineList{}
+	listOptions := []client.ListOption{
+		client.InNamespace("openshift-machine-api"),
+		client.MatchingLabels{masterMachineLabel: "master"},
+	}
+	err := kclient.List(context.TODO(), machineList, listOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return machineList, nil
+}
+
+// GetMasterNodeSubnets returns all the subnets for Machines with 'master' label.
+// return structure:
+// {
+//   public => subnetname,
+//   private => subnetname,
+// }
+//
+func GetMasterNodeSubnets(kclient client.Client) (map[string]string, error) {
+	subnets := make(map[string]string)
+	machineList, err := GetMasterMachines(kclient)
+	if err != nil {
+		return subnets, err
+	}
+	if len(machineList.Items) == 0 {
+		return subnets, fmt.Errorf("Did not find any master Machine objects")
+	}
+
+	// get the AZ from a Master object's providerSpec.
+	codec, err := awsproviderapi.NewCodec()
+
+	if err != nil {
+		return subnets, err
+	}
+
+	// Obtain the availability zone
+	awsconfig := &awsproviderapi.AWSMachineProviderConfig{}
+	err = codec.DecodeProviderSpec(&machineList.Items[0].Spec.ProviderSpec, awsconfig)
+	if err != nil {
+		return subnets, err
+	}
+
+	// Infra object gives us the Infrastructure name, which is the combination of
+	// cluster name and identifier.
+	infra, err := getInfrastructureObject(kclient)
+	if err != nil {
+		return subnets, err
+	}
+	subnets["public"] = fmt.Sprintf("%s-public-%s", infra.Status.InfrastructureName, awsconfig.Placement.AvailabilityZone)
+	subnets["private"] = fmt.Sprintf("%s-private-%s", infra.Status.InfrastructureName, awsconfig.Placement.AvailabilityZone)
+
+	return subnets, nil
+}
 
 // setDefaultAPIPublic sets the default API (api.<cluster-domain>) to public
 // scope
@@ -114,7 +190,7 @@ func (c *Client) setDefaultAPIPublic(ctx context.Context, kclient client.Client,
 		return err
 	}
 	extNLBName := infrastructureName + "-ext"
-	subnets, err := utils.GetMasterNodeSubnets(kclient)
+	subnets, err := GetMasterNodeSubnets(kclient)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/utils/clusterinfo.go
+++ b/pkg/controller/utils/clusterinfo.go
@@ -166,18 +166,6 @@ func getInfrastructureObject(kclient client.Client) (*configv1.Infrastructure, e
 	return infra, nil
 }
 
-// AWSOwnerTag returns owner taglist for the cluster
-func AWSOwnerTag(kclient client.Client) (map[string]string, error) {
-	m := make(map[string]string)
-	name, err := GetClusterName(kclient)
-	if err != nil {
-		return m, err
-	}
-
-	m[fmt.Sprintf("kubernetes.io/cluster/%s", name)] = "owned"
-	return m, nil
-}
-
 func readClusterRegionFromConfigMap(kclient client.Client) (string, error) {
 	cm, err := getClusterConfigMap(kclient)
 	if err != nil {

--- a/pkg/controller/utils/clusterinfo.go
+++ b/pkg/controller/utils/clusterinfo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -129,28 +128,6 @@ func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
 		return nil, err
 	}
 	return machineList, nil
-}
-
-// GetClusterMasterInstancesIDs gets all the instance IDs for Master nodes
-// For AWS the form is aws:///<availability zone>/<instance ID>
-// This could come from parsing the arbitrarily formatted .Status.ProviderStatus
-// but .Spec.ProviderID is standard
-func GetClusterMasterInstancesIDs(kclient client.Client) ([]string, error) {
-	machineList, err := GetMasterMachines(kclient)
-	if err != nil {
-		return []string{}, err
-	}
-
-	ids := make([]string, 0)
-
-	for _, machineObj := range machineList.Items {
-		r := strings.LastIndex(*machineObj.Spec.ProviderID, "/")
-		if r != -1 {
-			n := *machineObj.Spec.ProviderID
-			ids = append(ids, n[r+1:])
-		}
-	}
-	return ids, nil
 }
 
 func getInfrastructureObject(kclient client.Client) (*configv1.Infrastructure, error) {

--- a/pkg/controller/utils/clusterinfo_test.go
+++ b/pkg/controller/utils/clusterinfo_test.go
@@ -159,29 +159,6 @@ func TestMasterInstanceIDs(t *testing.T) {
 	}
 }
 
-func TestAWSOwnerTag(t *testing.T) {
-	clustername := "awstags-test"
-	infraObj := testutils.CreateInfraObject(clustername, testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
-	objs := []runtime.Object{infraObj}
-	mocks := testutils.NewTestMock(t, objs)
-	tags, err := AWSOwnerTag(mocks.FakeKubeClient)
-	if err != nil {
-		t.Fatalf("Couldn't get AWS owner tags %v", err)
-	}
-	// might add more tags(?), so check for non-zero
-	if len(tags) == 0 {
-		t.Fatalf("Zero tags returned, expected at least one")
-	}
-	expected := "kubernetes.io/cluster/awstags-test"
-	if v, ok := tags[expected]; ok {
-		if v != "owned" {
-			t.Fatalf("Expected owner tag %s to have value %s. Got %s", expected, "owned", v)
-		}
-	} else {
-		t.Fatalf("Expected to have a tag with key %s, but there wasn't one", expected)
-	}
-}
-
 // None of these should ever occur, but if they did, it'd be nice to know they return an error
 func TestNoInfraObj(t *testing.T) {
 	masterNames := make([]string, 3)
@@ -192,11 +169,7 @@ func TestNoInfraObj(t *testing.T) {
 	objs := []runtime.Object{machineList}
 	mocks := testutils.NewTestMock(t, objs)
 
-	_, err := AWSOwnerTag(mocks.FakeKubeClient)
-	if err == nil {
-		t.Fatalf("Expected to get an error from not having an Infrastructure object")
-	}
-	_, err = GetClusterRegion(mocks.FakeKubeClient)
+	_, err := GetClusterRegion(mocks.FakeKubeClient)
 	if err == nil {
 		t.Fatalf("Expected to get an error from not having an Infrastructure object")
 	}

--- a/pkg/controller/utils/clusterinfo_test.go
+++ b/pkg/controller/utils/clusterinfo_test.go
@@ -134,31 +134,6 @@ func TestGetClusterRegion(t *testing.T) {
 	}
 }
 
-func TestMasterInstanceIDs(t *testing.T) {
-	masterNames := make([]string, 3)
-	for i := 0; i < 3; i++ {
-		masterNames[i] = fmt.Sprintf("master-%d", i)
-	}
-	machineList, _ := testutils.CreateMachineObjectList(masterNames, "ids", "master", testutils.DefaultRegionName, testutils.DefaultAzName)
-	objs := []runtime.Object{machineList}
-	mocks := testutils.NewTestMock(t, objs)
-
-	ids, err := GetClusterMasterInstancesIDs(mocks.FakeKubeClient)
-	if err != nil {
-		t.Fatalf("Couldn't get master instance IDs %v", err)
-	}
-	if len(ids) != len(masterNames) {
-		t.Fatalf("Expected %d instance IDs, but got %d back", len(masterNames), len(ids))
-	}
-	// TODO(lseelye): It'd be nice if this matched up with the actual provider
-	// scheme instead of the contrived i-name
-	for _, id := range ids {
-		if id[0:9] != "i-master-" {
-			t.Fatalf("Expected master instance ID to begin with i-master-. Got %s", string(id[0:9]))
-		}
-	}
-}
-
 // None of these should ever occur, but if they did, it'd be nice to know they return an error
 func TestNoInfraObj(t *testing.T) {
 	masterNames := make([]string, 3)


### PR DESCRIPTION
Copied functions from clusterinfo.go  into private.go and aws.go in preparation for merging Publishingstrategy refactor. 