### PR TITLE
Tolerates new Infra Taint

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -27,6 +27,10 @@ spec:
         key: node-role.kubernetes.io
         value: infra
         effect: PreferNoSchedule
+      - operator: Equal
+        key: node-role.kubernetes.io
+        value: infra
+        effect: NoSchedule
       containers:
         - name: cloud-ingress-operator
           # Replace this with the built image name


### PR DESCRIPTION
Adds a new toleration for the upcoming infra taint change.  I'm leaving the old toleration because from my testing if the new taint is not pushed out these pods will be pushed out to worker nodes, but if the old toleration is left it will still land on the infra nodes.

If this is not the correct place to make this change I'm more than happy to learn where the correct place is :)

This work is related to https://issues.redhat.com/browse/OSD-2927