### PR TITLE
publishingstrategy: Avoid a potential nil pointer deference

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -376,7 +376,9 @@ func (r *ReconcilePublishingStrategy) ensureIngressControllersExist(appIngressLi
 		var exists bool
 		for _, ingress := range ingressControllerList.Items {
 			// prevent nil pointer error
-			if ingress.Spec.Domain == "" || ingress.Status.EndpointPublishingStrategy.LoadBalancer == nil {
+			if ingress.Spec.Domain == "" ||
+				ingress.Status.EndpointPublishingStrategy == nil ||
+				ingress.Status.EndpointPublishingStrategy.LoadBalancer == nil {
 				isContained = false
 				break
 			}


### PR DESCRIPTION
Controller crashed this morning on a fresh AWS cluster.

Based on the backtrace below this is my best guess at what might have caused it.

```
E1015 16:23:54.917091       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)                 
goroutine 871 [running]:                                                                                                                                                                              
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x190a880, 0x2cd1b20)                                                                                                                                   
        pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/runtime/runtime.go:74 +0xa3                                                                                           
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)                                                                                                                                       
        pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/runtime/runtime.go:48 +0x82                                                                                           
panic(0x190a880, 0x2cd1b20)                                                                                                                                                                           
        /usr/local/go/src/runtime/panic.go:679 +0x1b2                                                                                                                                                 
github.com/openshift/cloud-ingress-operator/pkg/controller/publishingstrategy.(*ReconcilePublishingStrategy).ensureIngressControllersExist(0xc0008f2ae0, 0xc0021a1180, 0x1, 0x1, 0xc00015e380, 0xc000d
46190)                                                                                                                                                                                                
        /workdir/pkg/controller/publishingstrategy/publishingstrategy_controller.go:379 +0xf3                                                                                                         
github.com/openshift/cloud-ingress-operator/pkg/controller/publishingstrategy.(*ReconcilePublishingStrategy).Reconcile(0xc0008f2ae0, 0xc002194b20, 0x20, 0xc002194b00, 0x12, 0xc0007e6cd8, 0xc0001f0b4
0, 0xc0001f0878, 0x1e99d60)                                                                                                                                                                           
        /workdir/pkg/controller/publishingstrategy/publishingstrategy_controller.go:175 +0xa31                                                                                                        
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000109b80, 0x19985e0, 0xc003e9dc00, 0x0)                                                                     
        pkg/mod/sigs.k8s.io/controller-runtime@v0.5.6/pkg/internal/controller/controller.go:245 +0x162                                                                                                
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000109b80, 0x0)                                                                                           
        pkg/mod/sigs.k8s.io/controller-runtime@v0.5.6/pkg/internal/controller/controller.go:221 +0xcb                                                                                                
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000109b80)
        pkg/mod/sigs.k8s.io/controller-runtime@v0.5.6/pkg/internal/controller/controller.go:200 +0x2b                                                                                                
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000d46c30)
        pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:152 +0x5e                                                                                               
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000d46c30, 0x3b9aca00, 0x0, 0x1, 0xc0005c3ce0)
        pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:153 +0xf8                                                                                               
k8s.io/apimachinery/pkg/util/wait.Until(0xc000d46c30, 0x3b9aca00, 0xc0005c3ce0)
        pkg/mod/k8s.io/apimachinery@v0.0.0-20191004115801-a2eda9f80ab8/pkg/util/wait/wait.go:88 +0x4d                                                                                                
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        pkg/mod/sigs.k8s.io/controller-runtime@v0.5.6/pkg/internal/controller/controller.go:182 +0x549                                                                                               
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x16305b3]
```