### PR TITLE
Support Updating Existing IngressController

### DIFF
--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -26,6 +26,7 @@ rules:
     - watch
     - delete
     - create
+    - update
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
@@ -375,14 +375,9 @@ func TestIngressHandle(t *testing.T) {
 		Name: "new-certificate",
 	}
 
-	err = r.defaultIngressHandle(mockPublishingStrategy().Spec.ApplicationIngress[0], list, newCertificate)
+	err = r.createOrUpdateIngressController(mockPublishingStrategy().Spec.ApplicationIngress[0], newCertificate)
 	if err != nil {
 		t.Fatalf("couldn't handle default ingress")
-	}
-
-	err = r.nonDefaultIngressHandle(mockPublishingStrategy().Spec.ApplicationIngress[1], list, newCertificate)
-	if err != nil {
-		t.Fatalf("couldn't handle non-default ingress")
 	}
 }
 
@@ -422,11 +417,6 @@ func TestDeleteIngressWithAnnotation(t *testing.T) {
 	err = r.client.List(ctx, ingressControllerList, &opts)
 	if err != nil {
 		t.Errorf("couldn't get ingresscontroller list %s", err)
-	}
-	// if ingress without annotation hit method, then it should not be removed
-	err = r.deleteIngressWithAnnotation(mockPublishingStrategy().Spec.ApplicationIngress, ingressControllerList)
-	if err != nil {
-		t.Fatalf("couldn't delete ingress")
 	}
 
 	err = r.client.List(ctx, ingressControllerList, &opts)


### PR DESCRIPTION
This change depends on https://github.com/openshift/cluster-ingress-operator/pull/472 (targeted for 4.7) and https://github.com/openshift/cluster-ingress-operator/pull/482 (for 4.6).

This changes the way cloud-ingress-operator reconciles the IngressController CR and removes the need to delete all CRs before adding new CRs (which was highly disruptive).

Tested on a stage 4.6 cluster (drow-10-20-20) with both modified operators.

Update 4-13-21:
Changes to support mutable loadbalancer scope were pulled from the OCP 4.7 and 4.6 releases due to security concerns. Work has been restarted to address this in a more secure manner here: https://github.com/openshift/cluster-ingress-operator/pull/582