### PR TITLE
publishingstrategy: Check Domain value in Status, not Spec

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -398,7 +398,7 @@ func doesIngressControllerExist(appIngress cloudingressv1alpha1.ApplicationIngre
 
 		listening := string(appIngress.Listening)
 		capListening := strings.Title(strings.ToLower(listening))
-		if ingress.Spec.Domain == appIngress.DNSName && capListening == string(ingress.Status.EndpointPublishingStrategy.LoadBalancer.Scope) {
+		if ingress.Status.Domain == appIngress.DNSName && capListening == string(ingress.Status.EndpointPublishingStrategy.LoadBalancer.Scope) {
 			return true
 		}
 	}
@@ -406,7 +406,7 @@ func doesIngressControllerExist(appIngress cloudingressv1alpha1.ApplicationIngre
 }
 
 func validateIngress(ingressController operatorv1.IngressController) bool {
-	if ingressController.Spec.Domain == "" ||
+	if ingressController.Status.Domain == "" ||
 		ingressController.Status.EndpointPublishingStrategy == nil ||
 		ingressController.Status.EndpointPublishingStrategy.LoadBalancer == nil {
 		return false
@@ -461,7 +461,7 @@ func contains(appIngressList []cloudingressv1alpha1.ApplicationIngress, ingressC
 		}
 		// set bool to true if it is non-default and have the proper annotations
 		if ingressController.Name != "default" && ingressController.Annotations["Owner"] == "cloud-ingress-operator" {
-			if ingressController.Spec.Domain == app.DNSName {
+			if ingressController.Status.Domain == app.DNSName {
 				isContained = true
 			}
 		}
@@ -597,12 +597,12 @@ func newApplicationIngressControllerCR(ingressControllerCRName, scope, dnsName s
 	}, nil
 }
 
-// convertIngressControllerToMap takes in on cluster ingresscontroller list and returns them as a map with key Spec.Domain and value operatorv1.IngressController
+// convertIngressControllerToMap takes in on cluster ingresscontroller list and returns them as a map with key Status.Domain and value operatorv1.IngressController
 func convertIngressControllerToMap(existingIngress []operatorv1.IngressController) map[string]operatorv1.IngressController {
 	ingressMap := make(map[string]operatorv1.IngressController)
 
 	for _, ingress := range existingIngress {
-		ingressMap[ingress.Spec.Domain] = ingress
+		ingressMap[ingress.Status.Domain] = ingress
 	}
 	return ingressMap
 }
@@ -621,7 +621,7 @@ func checkExistingIngress(existingMap map[string]operatorv1.IngressController, p
 
 // doesIngressMatch checks if application ingress in PublishingStrategy CR matches with IngressController CR
 func isOnCluster(publishingStrategyIngress *cloudingressv1alpha1.ApplicationIngress, ingressController operatorv1.IngressController) bool {
-	if publishingStrategyIngress.DNSName != ingressController.Spec.Domain {
+	if publishingStrategyIngress.DNSName != ingressController.Status.Domain {
 		log.Info("ApplicationIngress.DNSName mismatch",
 			"ApplicationIngress", publishingStrategyIngress,
 			"IngressController", ingressController)

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
@@ -31,6 +31,7 @@ func mockIngressControllerList() *operatorv1.IngressControllerList {
 					},
 				},
 				Status: operatorv1.IngressControllerStatus{
+					Domain: "example-domain",
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 						Type: operatorv1.LoadBalancerServiceStrategyType,
 						LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -47,6 +48,7 @@ func mockIngressControllerList() *operatorv1.IngressControllerList {
 					Domain: "example-non-default-domain",
 				},
 				Status: operatorv1.IngressControllerStatus{
+					Domain: "example-non-default-domain",
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 						Type: operatorv1.LoadBalancerServiceStrategyType,
 						LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -66,6 +68,7 @@ func mockIngressControllerList() *operatorv1.IngressControllerList {
 					},
 				},
 				Status: operatorv1.IngressControllerStatus{
+					Domain: "example-domain-3",
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 						Type: operatorv1.LoadBalancerServiceStrategyType,
 						// LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -90,6 +93,7 @@ func mockDefaultIngressController() *operatorv1.IngressController {
 			},
 		},
 		Status: operatorv1.IngressControllerStatus{
+			Domain: "example-domain",
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 				Type: operatorv1.LoadBalancerServiceStrategyType,
 				LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -115,6 +119,7 @@ func mockNonDefaultIngressController() *operatorv1.IngressController {
 			},
 		},
 		Status: operatorv1.IngressControllerStatus{
+			Domain: "apps2.exaple-nondefault-domain-to-pass-in",
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 				Type: operatorv1.LoadBalancerServiceStrategyType,
 				LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -137,6 +142,7 @@ func mockNonDefaultIngressNoAnnotation() *operatorv1.IngressController {
 			},
 		},
 		Status: operatorv1.IngressControllerStatus{
+			Domain: "apps2.exaple-nondefault-domain-with-no-annotation",
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 				Type: operatorv1.LoadBalancerServiceStrategyType,
 				LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -530,6 +536,7 @@ func TestEnsureIngressControllersExist(t *testing.T) {
 					},
 				},
 				Status: operatorv1.IngressControllerStatus{
+					Domain: "exaple-domain-to-pass-in",
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 						Type: operatorv1.LoadBalancerServiceStrategyType,
 						LoadBalancer: &operatorv1.LoadBalancerStrategy{
@@ -546,6 +553,7 @@ func TestEnsureIngressControllersExist(t *testing.T) {
 					Domain: "apps2.exaple-nondefault-domain-to-pass-in",
 				},
 				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps2.exaple-nondefault-domain-to-pass-in",
 					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 						Type: operatorv1.LoadBalancerServiceStrategyType,
 						LoadBalancer: &operatorv1.LoadBalancerStrategy{


### PR DESCRIPTION
The initial "default" IngressController has no Domain value in its Spec section, only its Status section.  This causes the controller
to unnecessarily delete and recreate the object.

See my findings in [OSD-5507](https://issues.redhat.com/browse/OSD-5507).