### PR TITLE
Refactor PublishingStrategy to simplify logic

### DIFF
--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -24,6 +24,7 @@ rules:
     - get
     - list
     - watch
+    - patch
     - delete
     - create
 - apiGroups:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -112,6 +112,7 @@ objects:
         - get
         - list
         - watch
+        - patch
         - delete
         - create
       - apiGroups:


### PR DESCRIPTION
Essentially a full refresh of the AppIngress logic. New workflow is:

For each definition in ApplicationIngress list:
- Check if it exists on cluster. If it doesn't create it
- If it does, check if the specs match
- If they don't, delete it, unless its default. If its default check the status
    - If the default status doesn't match the desired spec delete it

This makes the controller close to idempotent and simplifies the logic. The `defaultAPIServerIngress` logic in untouched. 