### PR TITLE
Add GCP cloud client (DNS methods only)

### DIFF
--- a/deploy/10_cloud-ingress-operator-credentials-aws.CredentialsRequest.yaml
+++ b/deploy/10_cloud-ingress-operator-credentials-aws.CredentialsRequest.yaml
@@ -1,11 +1,11 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: cloud-ingress-operator-credentials
+  name: cloud-ingress-operator-credentials-aws
   namespace: openshift-cloud-ingress-operator
 spec:
   secretRef:
-    name: cloud-ingress-operator-credentials
+    name: cloud-ingress-operator-credentials-aws
     namespace: openshift-cloud-ingress-operator
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/deploy/10_cloud-ingress-operator-credentials-gcp.CredentialsRequest.yaml
+++ b/deploy/10_cloud-ingress-operator-credentials-gcp.CredentialsRequest.yaml
@@ -1,0 +1,15 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cloud-ingress-operator-credentials-gcp
+  namespace: openshift-cloud-ingress-operator
+spec:
+  secretRef:
+    name: cloud-ingress-operator-credentials-gcp
+    namespace: openshift-cloud-ingress-operator
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/dns.admin
+    skipServiceCheck: true

--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -31,6 +31,7 @@ rules:
   resources:
     - infrastructures
     - apiservers
+    - dnses
   verbs:
     - list
     - get

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,8 @@ require (
 	github.com/operator-framework/operator-sdk v0.15.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	google.golang.org/api v0.6.1-0.20190607001116-5213b8090861
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
@@ -22,7 +23,7 @@ require (
 	k8s.io/utils v0.0.0-20191217005138-9e5e9d854fcc
 	sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.5.6
-	sigs.k8s.io/yaml v1.2.0
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // Pinned to kubernetes-1.16.2

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,7 @@ github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-migrate/migrate/v4 v4.6.2/go.mod h1:JYi6reN3+Z734VZ0akNuyOJNcrg45ZL7LDBMW3WGJL0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -800,6 +801,7 @@ gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -988,6 +990,7 @@ google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.3.2/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.6.1-0.20190607001116-5213b8090861 h1:ppLucX0K/60T3t6LPZQzTOkt5PytkEbQLIaSteq+TpE=
 google.golang.org/api v0.6.1-0.20190607001116-5213b8090861/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1005,6 +1008,7 @@ google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 h1:UXl+Zk3jqqcbEVV7ace5lrt4YdA4tXiz3f/KbmD29Vo=
 google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
@@ -1014,6 +1018,7 @@ google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -41,11 +41,11 @@ objects:
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest
       metadata:
-        name: cloud-ingress-operator-credentials
+        name: cloud-ingress-operator-credentials-aws
         namespace: openshift-cloud-ingress-operator
       spec:
         secretRef:
-          name: cloud-ingress-operator-credentials
+          name: cloud-ingress-operator-credentials-aws
           namespace: openshift-cloud-ingress-operator
         providerSpec:
           apiVersion: cloudcredential.openshift.io/v1

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -86,6 +86,21 @@ objects:
             - route53:ListHostedZonesByName
             - route53:ListResourceRecordSets
             - route53:UpdateHostedZoneComment
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
+      metadata:
+        name: cloud-ingress-operator-credentials-gcp
+        namespace: openshift-cloud-ingress-operator
+      spec:
+        secretRef:
+          name: cloud-ingress-operator-credentials-gcp
+          namespace: openshift-cloud-ingress-operator
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: GCPProviderSpec
+          predefinedRoles:
+          - roles/dns.admin
+          skipServiceCheck: true
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -134,6 +134,7 @@ objects:
         resources:
         - infrastructures
         - apiservers
+        - dnses
         verbs:
         - list
         - get

--- a/pkg/cloudclient/add_gcp.go
+++ b/pkg/cloudclient/add_gcp.go
@@ -1,0 +1,13 @@
+package cloudclient
+
+import (
+	"github.com/openshift/cloud-ingress-operator/pkg/cloudclient/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	Register(
+		gcp.ClientIdentifier,
+		func(kclient client.Client) CloudClient { return gcp.NewClient(kclient) },
+	)
+}

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -369,7 +369,7 @@ func (c *Client) doesELBExist(elbName string) (*awsLoadBalancer, error) {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case elb.ErrCodeAccessPointNotFoundException:
-				return &awsLoadBalancer{}, errors.NewLoadBalancerNotFoundError(elbName)
+				return &awsLoadBalancer{}, errors.NewLoadBalancerNotReadyError()
 			default:
 				return &awsLoadBalancer{}, err
 			}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -1,0 +1,109 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/oauth2/google"
+	dnsv1 "google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
+
+	configv1 "github.com/openshift/api/config/v1"
+	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+	"github.com/openshift/cloud-ingress-operator/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ClientIdentifier is what kind of cloud this implement supports
+const ClientIdentifier configv1.PlatformType = configv1.GCPPlatformType
+
+var (
+	log = logf.Log.WithName("gcp_cloudclient")
+)
+
+// Client represents a GCP Client
+type Client struct {
+	projectID  string
+	dnsService *dnsv1.Service
+}
+
+// EnsureAdminAPIDNS implements cloudclient.CloudClient
+func (c *Client) EnsureAdminAPIDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.APIScheme, svc *corev1.Service) error {
+	return c.ensureAdminAPIDNS(ctx, kclient, instance, svc)
+}
+
+// DeleteAdminAPIDNS implements cloudclient.CloudClient
+func (c *Client) DeleteAdminAPIDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.APIScheme, svc *corev1.Service) error {
+	return c.deleteAdminAPIDNS(ctx, kclient, instance, svc)
+}
+
+// EnsureSSHDNS implements cloudclient.CloudClient
+func (c *Client) EnsureSSHDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.SSHD, svc *corev1.Service) error {
+	return c.ensureSSHDNS(ctx, kclient, instance, svc)
+}
+
+// DeleteSSHDNS implements cloudclient.CloudClient
+func (c *Client) DeleteSSHDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.SSHD, svc *corev1.Service) error {
+	return c.deleteSSHDNS(ctx, kclient, instance, svc)
+}
+
+// SetDefaultAPIPrivate implements cloudclient.CloudClient
+func (c *Client) SetDefaultAPIPrivate(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.PublishingStrategy) error {
+	return c.setDefaultAPIPrivate(ctx, kclient, instance)
+}
+
+// SetDefaultAPIPublic implements cloudclient.CloudClient
+func (c *Client) SetDefaultAPIPublic(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.PublishingStrategy) error {
+	return c.setDefaultAPIPublic(ctx, kclient, instance)
+}
+
+func newClient(ctx context.Context, serviceAccountJSON []byte) (*Client, error) {
+	credentials, err := google.CredentialsFromJSON(
+		ctx, serviceAccountJSON,
+		dnsv1.NdevClouddnsReadwriteScope)
+	if err != nil {
+		return nil, err
+	}
+
+	dnsService, err := dnsv1.NewService(ctx, option.WithCredentials(credentials))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		projectID:  credentials.ProjectID,
+		dnsService: dnsService,
+	}, nil
+}
+
+// NewClient creates a new CloudClient for use with GCP.
+func NewClient(kclient client.Client) *Client {
+	ctx := context.Background()
+	secret := &corev1.Secret{}
+	err := kclient.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      config.GCPSecretName,
+			Namespace: config.OperatorNamespace,
+		},
+		secret)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't get Secret with credentials %s", err.Error()))
+	}
+	serviceAccountJSON, ok := secret.Data["service_account.json"]
+	if !ok {
+		panic(fmt.Sprintf("Access credentials missing service account"))
+	}
+
+	c, err := newClient(ctx, serviceAccountJSON)
+
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't create GCP client %s", err.Error()))
+	}
+
+	return c
+}

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -5,10 +5,20 @@ package gcp
 import (
 	"context"
 	"errors"
+	"net/http"
+	"reflect"
 
+	gdnsv1 "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+
+	configv1 "github.com/openshift/api/config/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cioerrors "github.com/openshift/cloud-ingress-operator/pkg/errors"
+	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
 )
 
 // ensureAdminAPIDNS ensures the DNS record for the "admin API" Service
@@ -48,9 +58,146 @@ func (c *Client) setDefaultAPIPublic(ctx context.Context, kclient client.Client,
 }
 
 func (c *Client) ensureDNSForService(kclient client.Client, svc *corev1.Service, dnsName string) error {
-	return errors.New("ensureDNSForService is not implemented")
+	// google.golang.org/api/dns/v1.Service is a struct, not an interface, which
+	// will make this all but impossible to write unit tests for
+
+	svcIPs, err := getIPAddressesFromService(svc)
+	if err != nil {
+		return err
+	}
+
+	baseDomain, err := baseutils.GetClusterBaseDomain(kclient)
+	if err != nil {
+		return err
+	}
+	FQDN := dnsName + "." + baseDomain + "."
+
+	// The resource record set to add.
+	// Kind and SignatureRrdatas are set as
+	// they are to satisfy reflect.DeepEqual.
+	newRRSet := &gdnsv1.ResourceRecordSet{
+		Kind:             "dns#resourceRecordSet",
+		Name:             FQDN,
+		Rrdatas:          svcIPs,
+		SignatureRrdatas: []string{},
+		Type:             "A",
+		Ttl:              30,
+	}
+
+	clusterDNS := &configv1.DNS{}
+	err = kclient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, clusterDNS)
+	if err != nil {
+		return err
+	}
+
+	var zones []configv1.DNSZone
+	if clusterDNS.Spec.PublicZone != nil {
+		zones = append(zones, *clusterDNS.Spec.PublicZone)
+	}
+	if clusterDNS.Spec.PrivateZone != nil {
+		zones = append(zones, *clusterDNS.Spec.PrivateZone)
+	}
+
+	for _, zone := range zones {
+		dnsChange := &gdnsv1.Change{
+			Additions: []*gdnsv1.ResourceRecordSet{newRRSet},
+		}
+
+		// Look for an existing resource record set in the zone.
+		listCall := c.dnsService.ResourceRecordSets.List(c.projectID, zone.ID)
+		response, err := listCall.Name(FQDN).Do()
+		if err != nil {
+			return err
+		}
+
+		// There will be at most one result but loop anyway.
+		// An empty slice will proceed directly to Create.
+		for _, rrset := range response.Rrsets {
+			if reflect.DeepEqual(newRRSet, rrset) {
+				dnsChange.Additions = []*gdnsv1.ResourceRecordSet{}
+			} else {
+				dnsChange.Deletions = append(dnsChange.Deletions, rrset)
+			}
+		}
+
+		if len(dnsChange.Additions) > 0 {
+			log.Info("Submitting DNS changes:", "Zone", zone.ID,
+				"Additions", dnsChange.Additions, "Deletions", dnsChange.Deletions)
+			changesCall := c.dnsService.Changes.Create(c.projectID, zone.ID, dnsChange)
+			_, err = changesCall.Do()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *Client) removeDNSForService(kclient client.Client, svc *corev1.Service, dnsName string) error {
-	return errors.New("removeDNSForService is not implemented")
+	// google.golang.org/api/dns/v1.Service is a struct, not an interface, which
+	// will make this all but impossible to write unit tests for
+
+	baseDomain, err := baseutils.GetClusterBaseDomain(kclient)
+	if err != nil {
+		return err
+	}
+	FQDN := dnsName + "." + baseDomain + "."
+
+	clusterDNS := &configv1.DNS{}
+	err = kclient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, clusterDNS)
+	if err != nil {
+		return err
+	}
+
+	var zones []configv1.DNSZone
+	if clusterDNS.Spec.PublicZone != nil {
+		zones = append(zones, *clusterDNS.Spec.PublicZone)
+	}
+	if clusterDNS.Spec.PrivateZone != nil {
+		zones = append(zones, *clusterDNS.Spec.PrivateZone)
+	}
+
+	for _, zone := range zones {
+		dnsChange := &gdnsv1.Change{}
+
+		// Look for an existing resource record set in the zone.
+		listCall := c.dnsService.ResourceRecordSets.List(c.projectID, zone.ID)
+		response, err := listCall.Name(FQDN).Do()
+		if err != nil {
+			return err
+		}
+
+		// There will be at most one result but loop anyway.
+		for _, rrset := range response.Rrsets {
+			dnsChange.Deletions = append(dnsChange.Deletions, rrset)
+		}
+
+		if len(dnsChange.Deletions) > 0 {
+			log.Info("Submitting DNS changes:", "Zone", zone.ID, "Deletions", dnsChange.Deletions)
+			call := c.dnsService.Changes.Create(c.projectID, zone.ID, dnsChange)
+			_, err = call.Do()
+			if err != nil {
+				dnsError, ok := err.(*googleapi.Error)
+				if !ok || dnsError.Code != http.StatusNotFound {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func getIPAddressesFromService(svc *corev1.Service) ([]string, error) {
+	var ips []string
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		ips = append(ips, ingress.IP)
+	}
+
+	if len(ips) == 0 {
+		return nil, cioerrors.NewLoadBalancerNotReadyError()
+	}
+
+	return ips, nil
 }

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -1,0 +1,56 @@
+package gcp
+
+// "Private" or non-interface conforming methods
+
+import (
+	"context"
+	"errors"
+
+	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ensureAdminAPIDNS ensures the DNS record for the "admin API" Service
+// LoadBalancer is accurately set
+func (c *Client) ensureAdminAPIDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.APIScheme, svc *corev1.Service) error {
+	return c.ensureDNSForService(kclient, svc, instance.Spec.ManagementAPIServerIngress.DNSName)
+}
+
+// deleteAdminAPIDNS ensures the DNS record for the "admin API" Service
+// LoadBalancer is deleted
+func (c *Client) deleteAdminAPIDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.APIScheme, svc *corev1.Service) error {
+	return c.removeDNSForService(kclient, svc, instance.Spec.ManagementAPIServerIngress.DNSName)
+}
+
+// ensureSSHDNS ensures the DNS record for the SSH Service LoadBalancer
+// is accurately set
+func (c *Client) ensureSSHDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.SSHD, svc *corev1.Service) error {
+	return c.ensureDNSForService(kclient, svc, instance.Spec.DNSName)
+}
+
+// deleteSSHDNS ensures the DNS record for the SSH Service LoadBalancer
+// is deleted
+func (c *Client) deleteSSHDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.SSHD, svc *corev1.Service) error {
+	return c.removeDNSForService(kclient, svc, instance.Spec.DNSName)
+}
+
+// setDefaultAPIPrivate sets the default api (api.<cluster-domain>) to private
+// scope
+func (c *Client) setDefaultAPIPrivate(ctx context.Context, kclient client.Client, _ *cloudingressv1alpha1.PublishingStrategy) error {
+	return errors.New("setDefaultAPIPrivate is not implemented")
+}
+
+// setDefaultAPIPublic sets the default API (api.<cluster-domain>) to public
+// scope
+func (c *Client) setDefaultAPIPublic(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.PublishingStrategy) error {
+	return errors.New("setDefaultAPIPublic is not implemented")
+}
+
+func (c *Client) ensureDNSForService(kclient client.Client, svc *corev1.Service, dnsName string) error {
+	return errors.New("ensureDNSForService is not implemented")
+}
+
+func (c *Client) removeDNSForService(kclient client.Client, svc *corev1.Service, dnsName string) error {
+	return errors.New("removeDNSForService is not implemented")
+}

--- a/pkg/cloudclient/gcp/private_test.go
+++ b/pkg/cloudclient/gcp/private_test.go
@@ -1,0 +1,97 @@
+package gcp
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cioerrors "github.com/openshift/cloud-ingress-operator/pkg/errors"
+)
+
+func TestGetIPAddressesFromService(t *testing.T) {
+	tests := []struct {
+		name         string
+		svc          *corev1.Service
+		expected_ips []string
+		expected_err error
+	}{
+		{
+			name: "single IP",
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: corev1.SchemeGroupVersion.String(),
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected_ips: []string{
+				"127.0.0.1",
+			},
+		},
+		{
+			name: "multiple IPs",
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: corev1.SchemeGroupVersion.String(),
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "127.0.0.1",
+							},
+							{
+								IP: "10.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected_ips: []string{
+				"127.0.0.1",
+				"10.0.0.1",
+			},
+		},
+		{
+			name: "no IPs",
+			svc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: corev1.SchemeGroupVersion.String(),
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{},
+					},
+				},
+			},
+			expected_ips: nil,
+			expected_err: cioerrors.NewLoadBalancerNotReadyError(),
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := getIPAddressesFromService(test.svc)
+
+		if !reflect.DeepEqual(actual, test.expected_ips) {
+			t.Errorf("%s: expected %v, got %v", test.name, actual, test.expected_ips)
+		}
+
+		actualErrorType := reflect.TypeOf(err)
+		expectErrorType := reflect.TypeOf(test.expected_err)
+		if actualErrorType != expectErrorType {
+			t.Errorf("%s error: expected %v, got %v", test.name, actualErrorType, expectErrorType)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,9 @@ const (
 	// AWSSecretName
 	AWSSecretName string = "cloud-ingress-operator-credentials-aws"
 
+	// GCPSecretName
+	GCPSecretName string = "cloud-ingress-operator-credentials-gcp"
+
 	// OperatorNamespace
 	OperatorNamespace string = "openshift-cloud-ingress-operator"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,7 @@ const (
 	MaxAPIRetries int = 10
 
 	// AWSSecretName
-	AWSSecretName string = "cloud-ingress-operator-credentials"
+	AWSSecretName string = "cloud-ingress-operator-credentials-aws"
 
 	// OperatorNamespace
 	OperatorNamespace string = "openshift-cloud-ingress-operator"

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -173,7 +173,7 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 				switch err {
 				case nil:
 					// all good
-				case err.(*cioerrors.LoadBalancerNotFoundError):
+				case err.(*cioerrors.LoadBalancerNotReadyError):
 					// couldn't find the load balancer - it's likely still queued for creation
 					SetAPISchemeStatus(instance, "Couldn't reconcile", "Load balancer isn't ready", cloudingressv1alpha1.ConditionError)
 					r.client.Status().Update(context.TODO(), instance)
@@ -249,8 +249,7 @@ func (r *ReconcileAPIScheme) Reconcile(request reconcile.Request) (reconcile.Res
 		SetAPISchemeStatus(instance, "Couldn't reconcile", "Couldn't ensure the admin API endpoint: "+err.Error(), cloudingressv1alpha1.ConditionError)
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
-	case err.(*cioerrors.LoadBalancerNotFoundError):
-		// couldn't find the new ELB yet
+	case err.(*cioerrors.LoadBalancerNotReadyError):
 		SetAPISchemeStatus(instance, "Couldn't reconcile", "Load balancer isn't ready", cloudingressv1alpha1.ConditionError)
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil

--- a/pkg/controller/sshd/sshd_controller.go
+++ b/pkg/controller/sshd/sshd_controller.go
@@ -174,8 +174,7 @@ func (r *ReconcileSSHD) Reconcile(request reconcile.Request) (reconcile.Result, 
 			switch err {
 			case nil:
 				// all good
-			case err.(*cioerrors.LoadBalancerNotFoundError):
-				// couldn't find the load balancer - it's likely still queued for creation
+			case err.(*cioerrors.LoadBalancerNotReadyError):
 				r.SetSSHDStatus(instance, "Couldn't reconcile", "Load balancer isn't ready.")
 				r.client.Status().Update(context.TODO(), instance)
 				return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
@@ -362,8 +361,7 @@ func (r *ReconcileSSHD) Reconcile(request reconcile.Request) (reconcile.Result, 
 	switch err {
 	case nil:
 		// all good
-	case err.(*cioerrors.LoadBalancerNotFoundError):
-		// couldn't find the new load balancer yet
+	case err.(*cioerrors.LoadBalancerNotReadyError):
 		r.SetSSHDStatus(instance, "Couldn't reconcile", "Load balancer isn't ready yet.")
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 )
 
-type LoadBalancerNotFoundError struct {
+type LoadBalancerNotReadyError struct {
 	e string
 }
 
-func (e *LoadBalancerNotFoundError) Error() string { return e.e }
+func (e *LoadBalancerNotReadyError) Error() string { return e.e }
 
-func NewLoadBalancerNotFoundError(lb string) error {
-	return &LoadBalancerNotFoundError{
-		e: fmt.Sprintf("Could not find LoadBalancer %s", lb),
+func NewLoadBalancerNotReadyError() error {
+	return &LoadBalancerNotReadyError{
+		e: "Load balancer for service is not yet ready",
 	}
 }
 


### PR DESCRIPTION
This is just to get some tests running. It's a rebase of the cloudclient-gcp branch

**NOTE:** The `SetDefaultAPIPublic` and `SetDefaultAPIPrivate` methods for GCP are not part of this PR.  @blrm is working on this part and will submit a separate PR when ready.