### PR TITLE
Regenerate syncset

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -99,6 +99,7 @@ objects:
           kind: GCPProviderSpec
           predefinedRoles:
           - roles/dns.admin
+          - roles/compute.networkAdmin
           skipServiceCheck: true
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole


### PR DESCRIPTION
A change made to one the deploy manifests wasn't included. Regenerating SS with `make generate-syncset`