### PR TITLE
Add report status from OSD operators to OCM

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -10,6 +10,9 @@ parameters:
 - name: REPO_NAME
   value: cloud-ingress-operator
   required: true
+- name: OPERATOR_NAME
+  value: cloud-ingress-operator
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
@@ -20,6 +23,10 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    annotations:
+      component-display-name: Cloud Ingress Operator
+      component-name: ${OPERATOR_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -10,8 +10,8 @@ parameters:
 - name: REPO_NAME
   value: cloud-ingress-operator
   required: true
-- name: OPERATOR_NAME
-  value: cloud-ingress-operator
+- name: DISPLAY_NAME
+  value: Cloud Ingress Operator
   required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
@@ -24,9 +24,9 @@ objects:
   kind: SelectorSyncSet
   metadata:
     annotations:
-      component-display-name: Cloud Ingress Operator
-      component-name: ${OPERATOR_NAME}
-      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+      component-display-name: ${DISPLAY_NAME}
+      component-name: ${REPO_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SDE-591

parsing the template using oc process --local looks like this:

```
"telemeter-query": "csv_succeeded{_id=\"$CLUSTER_ID\",name=~\"cloud-ingress-operator.*\",exported_namespace=~\"openshift-.*\",namespace=\"openshift-operator-lifecycle-manager\"} == 1"
```

The `CLUSTER_ID` parameter is not going to be replaced via this template, but from OCM.