### PR TITLE
Generate olm-artifacts-template.yaml

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -376,6 +376,10 @@ objects:
         dnsName: rh-ssh
         allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
         image: quay.io/app-sre/sre-ssh-proxy:v49-1fde8e5
+        configMapSelector:
+          matchExpressions:
+          - key: api.openshift.com/authorized-keys
+            operator: Exists
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
This was omitted from the [original PR](https://github.com/openshift/cloud-ingress-operator/pull/132) for [OSD-6101](https://issues.redhat.com/browse/OSD-6101).
(see commit [b422207d39a41c5107d1e59450e85147192ed1cc](https://github.com/openshift/cloud-ingress-operator/commit/b422207d39a41c5107d1e59450e85147192ed1cc))