### PR TITLE
RBAC permissions for sre-sshd client auth

### DIFF
--- a/deploy/35_sre-sshd-signer.Role.yaml
+++ b/deploy/35_sre-sshd-signer.Role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-sshd-signer
+  namespace: openshift-kube-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - csr-signer
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/deploy/35_sre-sshd-signer.RoleBinding.yaml
+++ b/deploy/35_sre-sshd-signer.RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-sshd-signer
+  namespace: openshift-kube-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sre-sshd-signer
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-sre-sshd

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -291,6 +291,33 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: sre-sshd-signer
+        namespace: openshift-kube-controller-manager
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - csr-signer
+        resources:
+        - secrets
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-sshd-signer
+        namespace: openshift-kube-controller-manager
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: sre-sshd-signer
+      subjects:
+      - kind: ServiceAccount
+        name: default
+        namespace: openshift-sre-sshd
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: prometheus-k8s
         namespace: openshift-cloud-ingress-operator
       rules:


### PR DESCRIPTION
These permissions are required before sre-ssh-proxy-container can be used for client auth

https://github.com/openshift/sre-ssh-proxy-container/pull/24/commits/022519eaf0e90a62aee3ef8d49e3306cd4bbd0e6