### PR TITLE
Metrics to record APISchemes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	"github.com/openshift/cloud-ingress-operator/pkg/collector"
 	// OSD metrics
 	"github.com/openshift/cloud-ingress-operator/pkg/localmetrics"
 	osdmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
@@ -136,7 +137,7 @@ func main() {
 	metricsServer := osdmetrics.NewBuilder().
 		WithPort(osdMetricsPort).
 		WithPath(osdMetricsPath).
-		WithCollectors(localmetrics.MetricsList).
+		WithCollectors(append(localmetrics.MetricsList, collector.NewCloudIngressCollector(mgr.GetClient()))).
 		WithServiceName("localmetrics-cloud-ingress-operator").
 		WithServiceMonitor().
 		GetConfig()

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,8 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/openshift/cloud-ingress-operator/pkg/collector"
-	// OSD metrics
-	"github.com/openshift/cloud-ingress-operator/pkg/localmetrics"
 	osdmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 )
 
@@ -137,7 +135,7 @@ func main() {
 	metricsServer := osdmetrics.NewBuilder().
 		WithPort(osdMetricsPort).
 		WithPath(osdMetricsPath).
-		WithCollectors(append(localmetrics.MetricsList, collector.NewCloudIngressCollector(mgr.GetClient()))).
+		WithCollectors(collector.NewCloudIngressCollectorList(mgr.GetClient())).
 		WithServiceName("localmetrics-cloud-ingress-operator").
 		WithServiceMonitor().
 		GetConfig()

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,0 +1,59 @@
+package collector
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+)
+
+var (
+	APISchemesDesc = prometheus.NewDesc(
+		"cloud_ingress_operator_apischemes",
+		"List of APISchemes",
+		[]string{
+			"name",
+			"namespace",
+		}, nil)
+)
+
+// CloudIngressCollector is implementing prometheus.Collector interface.
+type CloudIngressCollector struct {
+	client client.Client
+}
+
+func NewCloudIngressCollector(c client.Client) prometheus.Collector {
+	return &CloudIngressCollector{
+		client: c,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (cic *CloudIngressCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- APISchemesDesc
+}
+
+// Collect is method required to implement the prometheus.Collector(prometheus/client_golang/prometheus/collector.go) interface.
+func (cic *CloudIngressCollector) Collect(ch chan<- prometheus.Metric) {
+	cic.collectCloudIngressMetrics(ch)
+}
+
+func (cic *CloudIngressCollector) collectCloudIngressMetrics(ch chan<- prometheus.Metric) {
+	apiList := &v1alpha1.APISchemeList{}
+	err := cic.client.List(context.TODO(), apiList)
+	if err != nil {
+		return
+	}
+
+	for _, apis := range apiList.Items {
+		ch <- prometheus.MustNewConstMetric(
+			APISchemesDesc,
+			prometheus.GaugeValue,
+			float64(apis.CreationTimestamp.Unix()),
+			apis.Name,
+			apis.Namespace,
+		)
+	}
+}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -24,12 +24,6 @@ type CloudIngressCollector struct {
 	client client.Client
 }
 
-func NewCloudIngressCollector(c client.Client) prometheus.Collector {
-	return &CloudIngressCollector{
-		client: c,
-	}
-}
-
 // Describe implements the prometheus.Collector interface.
 func (cic *CloudIngressCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- APISchemesDesc

--- a/pkg/collector/collectors.go
+++ b/pkg/collector/collectors.go
@@ -1,0 +1,15 @@
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewCloudIngressCollectorList(c client.Client) []prometheus.Collector {
+	return []prometheus.Collector{
+		MetricDefaultIngressController,
+		&CloudIngressCollector{
+			client: c,
+		},
+	}
+}

--- a/pkg/collector/localmetrics.go
+++ b/pkg/collector/localmetrics.go
@@ -1,19 +1,12 @@
-package localmetrics
+package collector
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
-
-var log = logf.Log.WithName("localmetrics")
 
 var (
 	MetricDefaultIngressController = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "cloud_ingress_operator_default_ingress",
 		Help: "Report if default ingress is on cluster",
 	})
-
-	MetricsList = []prometheus.Collector{
-		MetricDefaultIngressController,
-	}
 )


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-6591

backplane relies on the rh-api endpoint to communicate with target clusters. There has [been a few times](https://issues.redhat.com/browse/OSD-6540) where we discovered the rh-api APIScheme was missing.
This PR will add metrics to record what APISchemes are in the cluster.
backplane team will add an alert for rh-api specifically based on this metric