### PR TITLE
Update controller to apply infra nodeSelectors to ingresscontrollers

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -30,6 +30,7 @@ import (
 const (
 	defaultIngressName         = "default"
 	ingressControllerNamespace = "openshift-ingress-operator"
+	infraNodeLabelKey          = "node-role.kubernetes.io/infra"
 )
 
 var log = logf.Log.WithName("controller_publishingstrategy")
@@ -378,11 +379,11 @@ func generateIngressController(appIngress v1alpha1.ApplicationIngress) *operator
 			},
 			NodePlacement: &operatorv1.NodePlacement{
 				NodeSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"node-role.kubernetes.io/infra": ""},
+					MatchLabels: map[string]string{infraNodeLabelKey: ""},
 				},
 				Tolerations: []corev1.Toleration{
 					{
-						Key:      "node-role.kubernetes.io/infra",
+						Key:      infraNodeLabelKey,
 						Effect:   corev1.TaintEffectNoSchedule,
 						Operator: corev1.TolerationOpExists,
 					},

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -39,6 +39,7 @@ type patchField string
 
 var IngressControllerSelector patchField = "IngressControllerSelector"
 var IngressControllerCertificate patchField = "IngressControllerCertificate"
+var IngressControllerNodePlacement patchField = "IngressControllerNodePlacement"
 
 // Add creates a new PublishingStrategy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -274,7 +275,11 @@ func (r *ReconcilePublishingStrategy) Reconcile(request reconcile.Request) (reco
 				} else if field == IngressControllerCertificate {
 					// If the DefaultCertificate doesn't match, replace the existing spec with the desired Spec
 					ingressController.Spec.DefaultCertificate = desiredIngressController.Spec.DefaultCertificate
+				} else if field == IngressControllerNodePlacement {
+					// If the NodePlacement doesn't match, replace the existing spec with the desired Spec
+					ingressController.Spec.NodePlacement = desiredIngressController.Spec.NodePlacement
 				}
+
 				// Perform the patch on the existing IngressController using the base to patch against and the
 				// changes added to bring the exsting CR to the desired state
 				err = r.client.Patch(context.TODO(), ingressController, baseToPatch)
@@ -370,6 +375,18 @@ func generateIngressController(appIngress v1alpha1.ApplicationIngress) *operator
 		Spec: operatorv1.IngressControllerSpec{
 			DefaultCertificate: &corev1.LocalObjectReference{
 				Name: appIngress.Certificate.Name,
+			},
+			NodePlacement: &operatorv1.NodePlacement{
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"node-role.kubernetes.io/infra": ""},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node-role.kubernetes.io/infra",
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpExists,
+					},
+				},
 			},
 			Domain: appIngress.DNSName,
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
@@ -478,6 +495,15 @@ func validatePatchableSpec(ingressController operatorv1.IngressController, desir
 
 	if !(desiredSpec.DefaultCertificate.Name == ingressController.Spec.DefaultCertificate.Name) {
 		return false, IngressControllerCertificate
+	}
+
+	// Preventing nil pointer errors
+	if ingressController.Spec.NodePlacement == nil {
+		return false, IngressControllerNodePlacement
+	}
+
+	if !(reflect.DeepEqual(desiredSpec.NodePlacement.NodeSelector.MatchLabels, ingressController.Spec.NodePlacement.NodeSelector.MatchLabels)) {
+		return false, IngressControllerNodePlacement
 	}
 
 	return true, ""

--- a/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller_test.go
@@ -421,6 +421,18 @@ func TestValidatePatchableSpec(t *testing.T) {
 			DefaultCertificate: &corev1.LocalObjectReference{
 				Name: "example-cert-nondefault",
 			},
+			NodePlacement: &operatorv1.NodePlacement{
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"node-role.kubernetes.io/infra": ""},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node-role.kubernetes.io/infra",
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpExists,
+					},
+				},
+			},
 			Domain: "example-domain.example.com",
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 				Type: operatorv1.LoadBalancerServiceStrategyType,
@@ -451,6 +463,18 @@ func TestValidatePatchableSpec(t *testing.T) {
 		Spec: operatorv1.IngressControllerSpec{
 			DefaultCertificate: &corev1.LocalObjectReference{
 				Name: "example-cert-nondefault",
+			},
+			NodePlacement: &operatorv1.NodePlacement{
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"node-role.kubernetes.io/infra": ""},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node-role.kubernetes.io/infra",
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpExists,
+					},
+				},
 			},
 			Domain: "example-domain.example.com",
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSD-5928, this updates the operator to patch the correct nodeSelector and tolerations onto any IngressControllers that it manages. This nodeSelector and toleration will ensure that all router pods are scheduled onto infra nodes. 

The unit tests have also been updated to account for the change in fields being managed on ingresscontrollers.