### PR TITLE
Ensure we have a DEPLOYED_HASH

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,12 @@ define create_push_catalog_image
 	mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
 	removed_versions="" ;\
 	if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+		echo "Current deployed production HASH: $$deployed_hash" ;\
+		if [[ ! "$${deployed_hash}" =~ [0-9a-f]{40}  ]]; then \
+		    echo "Error discovering current production deployed HASH" ;\
+		    exit 1 ;\
+		fi ;\
 		delete=false ;\
 		for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
 			if [[ "$${delete}" == false ]]; then \


### PR DESCRIPTION
Again difficult to debug see the script below the issue here is the missing `$` in the yq statement.

APPSRE SAAS files have different schemas depending on if its a Hive operator or not. We are silently failing on attempting to YQ an image from a file that doesn't exist, returning an empty hash.

This causes production catalog builds to look like staging bundles in respect to every version being added to the catalog.

For prod deploys don't deploy every version, this means on prod deploy there is a large jump from version to version causing CSV issues.

```
diff --git a/Makefile b/Makefile
index 2a50885..496950b 100644
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ skopeo-push: container-build
 
 .PHONY: build-catalog-image
 build-catalog-image:
-       $(call create_push_catalog_image,staging,service/saas-$(OPERATOR_NAME)-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGISTR
Y_ORGANIZATION))
+       #$(call create_push_catalog_image,staging,service/saas-$(OPERATOR_NAME)-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGIST
RY_ORGANIZATION))
        $(call create_push_catalog_image,production,service/saas-$(OPERATOR_NAME)-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,hack/generate-operator-bundle.py,$(CATALOG_REGIS
TRY_ORGANIZATION))
 
 .PHONY: boilerplate-update
diff --git a/functions.mk b/functions.mk
index 64255a8..64cc2a7 100644
--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,13 @@ define create_push_catalog_image
        mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
        removed_versions="" ;\
        if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-               deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+               deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+               echo "Current deployed production HASH: $$deployed_hash" ;\
+               if [[ ! "$${deployed_hash}" =~ [0-9a-f]{40}  ]]; then \
+                   echo "Error discovering current production deployed HASH" ;\
+                   exit 1 ;\
+               fi ;\
+               exit 1 ;\
                delete=false ;\
                for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
                        if [[ "$${delete}" == false ]]; then \
@@ -33,6 +39,7 @@ define create_push_catalog_image
                        fi ;\
                done ;\
        fi ;\
+    exit 1;\
        previous_version=$$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ;\
        if [[ -z $$previous_version ]]; then \
                previous_version=__undefined__ ;\

```

Example failing build where hash fails

```
make build-catalog-image 
#       set -e ; git clone --branch staging "https://app:$APP_SRE_BOT_PUSH_TOKEN@gitlab.cee.redhat.com/service/saas-cloud-ingress-operator-bundle.git" bundles-staging ; mkdir -p bundles-staging/cloud-ingress-operator ; removed_versions="" ; if [[ "$(echo
 false | tr [:upper:] [:lower:])" == "true" ]]; then deployed_hash=$(curl -s 'https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-cloud-ingress-operator.yaml' | /usr/bin/podman run --rm -i quay.io/app
-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.ef==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ; echo "Current deployed production HASH: $deployed_hash" ; if [[ ! "${deployed_hash}" =~ [0-9a-f]{40}  ]]; then echo 
"Error discovering current production deployed HASH" ; exit 1 ; fi ; exit 1 ; delete=false ; for bundle_path in $(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do if [[ "${delete}" == false ]]; then bundle=$(echo $bundle
_path | cut -d / -f 3-) ; version_hash=$(echo $bundle | cut -d - -f 2) ; if [[ 0.1.339-58cee84 == "${version_hash}"* ]]; then delete=true ; fi ; else \rm -rf "${bundle_path}" ; removed_versions="$bundle $removed_versions" ; fi ; done ; fi ; exit 1; previ
ous_version=$(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ; if [[ -z $previous_version ]]; then previous_version=__undefined__ ; else previous_version="cloud-ingress-operator.v${previous_vers
ion}" ; fi ; python hack/generate-operator-bundle.py bundles-staging/cloud-ingress-operator cloud-ingress-operator openshift-cloud-ingress-operator 0.1.339-58cee84 quay.io/jharrington22/cloud-ingress-operator:v0.1.339-58cee84 staging true $previous_versi
on ; new_version=$(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1 | cut -d / -f 3-) ; if [[ cloud-ingress-operator.v${new_version} == $previous_version ]]; then echo "Already built this, so no need to continue" 
; exit 0 ; fi ; sed -e "s/!CHANNEL!/staging/g" -e "s/!OPERATOR_NAME!/cloud-ingress-operator/g" -e "s/!VERSION!/${new_version}/g" hack/templates/package.yaml > bundles-staging/cloud-ingress-operator/cloud-ingress-operator.package.yaml ; cd bundles-staging
 ; git add . ; git commit -m "add version 339-58cee84" -m "replaces: $previous_version" -m "removed versions: $removed_versions" ; git push origin staging ; cd .. ; /usr/bin/podman build -f build/Dockerfile.catalog_registry --build-arg=SRC_BUNDLES=$(find
 bundles-staging -mindepth 1 -maxdepth 1 -type d | grep -v .git) -t quay.io/app-sre/cloud-ingress-operator-registry:staging-latest . ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/cloud-ingress-operator-registry:staging-
latest" "docker://quay.io/app-sre/cloud-ingress-operator-registry:staging-latest" ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/cloud-ingress-operator-registry:staging-latest" "docker://quay.io/app-sre/cloud-ingress-ope
rator-registry:staging-58cee84"
set -e ; git clone --branch production "https://app:$APP_SRE_BOT_PUSH_TOKEN@gitlab.cee.redhat.com/service/saas-cloud-ingress-operator-bundle.git" bundles-production ; mkdir -p bundles-production/cloud-ingress-operator ; removed_versions="" ; if [[ "$(ech
o true | tr [:upper:] [:lower:])" == "true" ]]; then deployed_hash=$(curl -s 'https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-cloud-ingress-operator.yaml' | /usr/bin/podman run --rm -i quay.io/app
-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.ef==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ; echo "Current deployed production HASH: $deployed_hash" ; if [[ ! "${deployed_hash}" =~ [0-9a-f]{40}  ]]; then echo 
"Error discovering current production deployed HASH" ; exit 1 ; fi ; exit 1 ; delete=false ; for bundle_path in $(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do if [[ "${delete}" == false ]]; then bundle=$(echo $bun
dle_path | cut -d / -f 3-) ; version_hash=$(echo $bundle | cut -d - -f 2) ; if [[ 0.1.339-58cee84 == "${version_hash}"* ]]; then delete=true ; fi ; else \rm -rf "${bundle_path}" ; removed_versions="$bundle $removed_versions" ; fi ; done ; fi ; exit 1; pr
evious_version=$(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ; if [[ -z $previous_version ]]; then previous_version=__undefined__ ; else previous_version="cloud-ingress-operator.v${previou
s_version}" ; fi ; python hack/generate-operator-bundle.py bundles-production/cloud-ingress-operator cloud-ingress-operator openshift-cloud-ingress-operator 0.1.339-58cee84 quay.io/jharrington22/cloud-ingress-operator:v0.1.339-58cee84 production true $pr
evious_version ; new_version=$(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1 | cut -d / -f 3-) ; if [[ cloud-ingress-operator.v${new_version} == $previous_version ]]; then echo "Already built this, so no nee
d to continue" ; exit 0 ; fi ; sed -e "s/!CHANNEL!/production/g" -e "s/!OPERATOR_NAME!/cloud-ingress-operator/g" -e "s/!VERSION!/${new_version}/g" hack/templates/package.yaml > bundles-production/cloud-ingress-operator/cloud-ingress-operator.package.yaml
 ; cd bundles-production ; git add . ; git commit -m "add version 339-58cee84" -m "replaces: $previous_version" -m "removed versions: $removed_versions" ; git push origin production ; cd .. ; /usr/bin/podman build -f build/Dockerfile.catalog_registry --b
uild-arg=SRC_BUNDLES=$(find bundles-production -mindepth 1 -maxdepth 1 -type d | grep -v .git) -t quay.io/app-sre/cloud-ingress-operator-registry:production-latest . ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/cloud-i
ngress-operator-registry:production-latest" "docker://quay.io/app-sre/cloud-ingress-operator-registry:production-latest" ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/cloud-ingress-operator-registry:production-latest" "
docker://quay.io/app-sre/cloud-ingress-operator-registry:production-58cee84"
Cloning into 'bundles-production'...
warning: redirecting to https://gitlab.cee.redhat.com/service/saas-cloud-ingress-operator-bundle.git/
remote: Enumerating objects: 135, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 1328 (delta 86), reused 115 (delta 73), pack-reused 1193
Receiving objects: 100% (1328/1328), 125.25 KiB | 179.00 KiB/s, done.
Resolving deltas: 100% (880/880), done.
Current deployed production HASH: 
Error discovering current production deployed HASH
make: *** [Makefile:66: build-catalog-image] Error 1
```

Example working with hash returned (exit 1 is from debug thats removed, see diff above)

```
Cloning into 'bundles-production'...                                                                                                                                                                                                                          
warning: redirecting to https://gitlab.cee.redhat.com/service/saas-cloud-ingress-operator-bundle.git/                                                                                                                                                         
remote: Enumerating objects: 135, done.                                                                                                                                                                                                                       
remote: Counting objects: 100% (135/135), done.                                                                                                                                                                                                               
remote: Compressing objects: 100% (40/40), done.                                                                                                                                                                                                              
remote: Total 1328 (delta 86), reused 115 (delta 73), pack-reused 1193                                                                                                                                                                                        
Receiving objects: 100% (1328/1328), 125.25 KiB | 183.00 KiB/s, done.                                                                                                                                                                                         
Resolving deltas: 100% (880/880), done.                                                                                                                                                                                                                       
Current deployed production HASH: 10af8dab0515ed5762aa283c83eb4080b0238fcd
make: *** [Makefile:66: build-catalog-image] Error 1
```