### PR TITLE
Set up shared credentials file for aws config

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -34,6 +34,12 @@ spec:
               path: tls-ca-bundle.pem
           name: trusted-ca-bundle
         name: trusted-ca-bundle
+      - name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              audience: openshift
       containers:
         - name: cloud-ingress-operator
           # Replace this with the built image name
@@ -67,4 +73,5 @@ spec:
           - mountPath: /etc/pki/ca-trust/extracted/pem
             name: trusted-ca-bundle
             readOnly: true
-            
+          - name: bound-sa-token
+            mountPath: /var/run/secrets/openshift/serviceaccount

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07
 	github.com/openshift/operator-custom-metrics v0.4.2
 	github.com/operator-framework/operator-sdk v0.18.2
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	google.golang.org/api v0.35.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxw
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v13.3.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.6/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/pkg/cloudclient/aws/shared_credentials_file.go
+++ b/pkg/cloudclient/aws/shared_credentials_file.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SharedCredentialsFileFromSecret returns a path to the shared creds file created using provided secret
+// configure the aws session using file to use credentials eg
+// sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
+// if err != nil {
+// 	// handle error
+// }
+// options := session.Options{
+// 	SharedConfigState: session.SharedConfigEnable,
+// 	SharedConfigFiles: []string{sharedCredentialsFile},
+// }
+// sess := session.Must(session.NewSessionWithOptions(options))
+func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
+	var data []byte
+	switch {
+	case len(secret.Data["credentials"]) > 0:
+		data = secret.Data["credentials"]
+	case len(secret.Data["aws_access_key_id"]) > 0 && len(secret.Data["aws_secret_access_key"]) > 0:
+		data = newConfigForStaticCreds(
+			string(secret.Data["aws_access_key_id"]),
+			string(secret.Data["aws_secret_access_key"]),
+		)
+
+	default:
+		return "", errors.New("invalid secret for aws credentials")
+
+	}
+
+	f, err := ioutil.TempFile("", "aws-shared-credentials")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create file for shared credentials")
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return "", errors.Wrapf(err, "failed to write credentials to %s", f.Name())
+	}
+
+	return f.Name(), nil
+
+}
+
+func newConfigForStaticCreds(accessKey string, accessSecret string) []byte {
+	buf := &bytes.Buffer{}
+	fmt.Fprint(buf, "[default]\n")
+	fmt.Fprintf(buf, "aws_access_key_id = %s\n", accessKey)
+	fmt.Fprintf(buf, "aws_secret_access_key = %s\n", accessSecret)
+	return buf.Bytes()
+}

--- a/pkg/cloudclient/aws/shared_credentials_file_test.go
+++ b/pkg/cloudclient/aws/shared_credentials_file_test.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNewConfigForStaticCreds(t *testing.T) {
+	cases := []struct {
+		key          string
+		secret       string
+		sharedConfig string
+	}{{
+		key:    `asdf`,
+		secret: `asdf1234`,
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}}
+
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			sharedConfig := newConfigForStaticCreds(test.key, test.secret)
+			assert.Equal(t, string(sharedConfig), test.sharedConfig)
+		})
+	}
+}
+
+func TestSharedCredentialsFileFromSecret(t *testing.T) {
+	cases := []struct {
+		data         map[string]string
+		sharedConfig string
+		err          string
+	}{{
+		data: map[string]string{
+			"aws_access_key_id":     "asdf",
+			"aws_secret_access_key": "asdf1234",
+		},
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}, {
+		data: map[string]string{
+			"credentials": `[default]
+assume_role = role_for_cloud_ingress_operator
+web_identity_token = /path/to/sa/token
+`,
+		},
+
+		sharedConfig: `[default]
+assume_role = role_for_cloud_ingress_operator
+web_identity_token = /path/to/sa/token
+`,
+	}, {
+		data: map[string]string{
+			"wrong_format_cred_file": "random_value",
+		},
+		// err should match the defaut case for SharedCredentialsFileFromSecret() func
+		// and return the exact same error message of `invalid secret for aws credentials`
+		err: "invalid secret for aws credentials",
+	}, {
+		data: map[string]string{
+			"aws_access_key_id":     "asdf",
+			"aws_secret_access_key": "asdf1234",
+			"credentials": `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+		},
+		sharedConfig: `[default]
+aws_access_key_id = asdf
+aws_secret_access_key = asdf1234
+`,
+	}}
+
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			secret := &corev1.Secret{
+				Data: map[string][]byte{},
+			}
+
+			for k, v := range test.data {
+				secret.Data[k] = []byte(v)
+			}
+
+			credPath, err := SharedCredentialsFileFromSecret(secret)
+			if credPath != "" {
+				defer os.Remove(credPath)
+			}
+
+			if test.err == "" {
+				assert.NoError(t, err)
+				data, err := ioutil.ReadFile(credPath)
+				t.Log(data)
+				assert.NoError(t, err)
+				assert.Equal(t, string(data), test.sharedConfig)
+			} else {
+				assert.Regexp(t, test.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements the AWS SDK's default handling of shared credentials file. Currently, this operator only supports static credentials from the aws_access_key_id and aws_secret_access_key in the aws secret.

This PR adds in support for another style of authentication by reading 'credentials' key to load shared credential file and use this to authenticate with AWS. The existing aws_access_key_id and aws_secret_access_key will be included in this shared credentials file.