### PR TITLE
Disable cloud-i-o on PrivateLink clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -43,6 +43,10 @@ objects:
         operator: NotIn
         values:
         - "true"
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - "true"
     resourceApplyMode: Upsert
     resources:
     - kind: Namespace


### PR DESCRIPTION
As part of OSD-7433, there is no need for cloud-ingress-operator to be running on PrivateLink clusters. This disables the operator altogether.