### PR TITLE
bug: add missing ns for caching: openshift-machine-api

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             # "" so that the cache can read objects outside its namespace
             - name: WATCH_NAMESPACE
-              value: "openshift-sre-sshd,openshift-cloud-ingress-operator,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver"
+              value: "openshift-sre-sshd,openshift-cloud-ingress-operator,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver,openshift-machine-api"
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OHSS-4489
Fix: https://issues.redhat.com/browse/OSD-7118

This fixes the error below when flipping a cluster to private
```
{"level":"error","ts":1622805815.9930809,"logger":"controller_publishingstrategy","msg":"Error updating api.boran-test-cio.iaps.s1.devshift.org alias to internal NLB","error":"unable to get: openshift-machine-api because of unknown namespace for the cache","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132\nsigs.k8s.io/controller-runtime/pkg/log.(*DelegatingLogger).Error\n\tpkg/mod/sig...
```
to
```
{"level":"info","ts":1622806348.865607,"logger":"controller_publishingstrategy","msg":"Update api.boran-test-cio.iaps.s1.devshift.org alias to internal NLB successful"}
```
