### PR TITLE
bug: fix crashloop due to err type mismatch

### DIFF
--- a/pkg/controller/sshd/sshd_controller.go
+++ b/pkg/controller/sshd/sshd_controller.go
@@ -171,10 +171,10 @@ func (r *ReconcileSSHD) Reconcile(ctx context.Context, request reconcile.Request
 			}
 
 			err = r.cloudClient.DeleteSSHDNS(context.TODO(), r.client, instance, svc)
-			switch err {
+			switch err := err.(type) {
 			case nil:
 				// all good
-			case err.(*cioerrors.LoadBalancerNotReadyError):
+			case *cioerrors.LoadBalancerNotReadyError:
 				r.SetSSHDStatus(instance, "Couldn't reconcile", "Load balancer isn't ready.")
 				return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 			default:
@@ -351,10 +351,10 @@ func (r *ReconcileSSHD) Reconcile(ctx context.Context, request reconcile.Request
 	}
 
 	err = r.cloudClient.EnsureSSHDNS(context.TODO(), r.client, instance, foundService)
-	switch err {
+	switch err := err.(type) {
 	case nil:
 		// all good
-	case err.(*cioerrors.LoadBalancerNotReadyError):
+	case *cioerrors.LoadBalancerNotReadyError:
 		r.SetSSHDStatus(instance, "Couldn't reconcile", "Load balancer isn't ready yet.")
 		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	default:


### PR DESCRIPTION
This to be fixing error type conversion mismatch and due to it being in crashloop continuously. 

```
E0605 13:33:11.415451 1086858 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x20f33c0), concrete:(*runtime._type)(0x20754a0), asserted:(*runtime._type)(0x2075440), missingMethod:""} (interface conversion: error is *errors.LoadBalancerNotReadyError, not *errors.DnsUpdateError)
goroutine 1609 [running]:
```