### PR TITLE
refactor: error handling, cli generation

### DIFF
--- a/pkg/cloudclient/add_aws.go
+++ b/pkg/cloudclient/add_aws.go
@@ -8,6 +8,13 @@ import (
 func init() {
 	Register(
 		aws.ClientIdentifier,
-		func(kclient client.Client) CloudClient { return aws.NewClient(kclient) },
+		func(kclient client.Client) CloudClient {
+			cli, err := aws.NewClient(kclient)
+			if err != nil {
+				panic(err)
+			}
+
+			return cli
+		},
 	)
 }

--- a/pkg/cloudclient/add_aws.go
+++ b/pkg/cloudclient/add_aws.go
@@ -8,13 +8,15 @@ import (
 func init() {
 	Register(
 		aws.ClientIdentifier,
-		func(kclient client.Client) CloudClient {
-			cli, err := aws.NewClient(kclient)
-			if err != nil {
-				panic(err)
-			}
-
-			return cli
-		},
+		produce,
 	)
+}
+
+func produce(kclient client.Client) CloudClient {
+	cli, err := aws.NewClient(kclient)
+	if err != nil {
+		panic(err)
+	}
+
+	return cli
 }

--- a/pkg/cloudclient/add_aws_test.go
+++ b/pkg/cloudclient/add_aws_test.go
@@ -1,0 +1,19 @@
+package cloudclient
+
+import (
+	"testing"
+
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestProduce(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("testing panic: should have been failed")
+		}
+	}()
+	objs := []runtime.Object{}
+	mocks := testutils.NewTestMock(t, objs)
+	_ = produce(mocks.FakeKubeClient)
+}

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuild(t *testing.T) {
+	secret := &corev1.Secret{
+		Data: make(map[string][]byte),
+	}
+	secret.Data["aws_access_key_id"] = []byte("fake")
+	secret.Data["aws_secret_access_key"] = []byte("fake")
+	region := "sut"
+
+	_, err := build(secret, region)
+	if err != nil {
+		t.Errorf("cli couldn't initialized: %w", err)
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	_, err := configure("XXX-SS", "XXX-TT", "eu-west-1")
+	if err != nil {
+		t.Errorf("cli couldn't configured: %w", err)
+	}
+}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -10,10 +10,10 @@ import (
 	"google.golang.org/api/option"
 
 	configv1 "github.com/openshift/api/config/v1"
-	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/config"
+	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -92,16 +92,9 @@ func newClient(ctx context.Context, serviceAccountJSON []byte) (*Client, error) 
 // NewClient creates a new CloudClient for use with GCP.
 func NewClient(kclient client.Client) *Client {
 	ctx := context.Background()
-	secret := &corev1.Secret{}
-	err := kclient.Get(
-		ctx,
-		types.NamespacedName{
-			Name:      config.GCPSecretName,
-			Namespace: config.OperatorNamespace,
-		},
-		secret)
+	secret, err := baseutils.GetCliSecret(kclient, config.GCPSecretName, config.OperatorNamespace)
 	if err != nil {
-		panic(fmt.Sprintf("Couldn't get Secret with credentials %s", err.Error()))
+		panic(err)
 	}
 	serviceAccountJSON, ok := secret.Data["service_account.json"]
 	if !ok {

--- a/pkg/utils/infrastructure.go
+++ b/pkg/utils/infrastructure.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -72,4 +73,20 @@ func GetPlatformType(kclient client.Client) (*configv1.PlatformType, error) {
 		return nil, err
 	}
 	return &infra.Status.PlatformStatus.Type, nil
+}
+
+func GetCliSecret(kclient client.Client, name, ns string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	err := kclient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: ns,
+		},
+		secret)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get Secret with credentials %w", err)
+	}
+
+	return secret, nil
 }

--- a/pkg/utils/infrastructure_test.go
+++ b/pkg/utils/infrastructure_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -58,5 +60,27 @@ func TestNoInfraObj(t *testing.T) {
 	_, err = GetPlatformType(mocks.FakeKubeClient)
 	if err == nil {
 		t.Fatalf("Expected to get an error from not having an Infrastructure object")
+	}
+}
+
+func TestGetCliSecret(t *testing.T) {
+	fakeSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake-name",
+			Namespace: "sut-ns",
+		},
+		Data: make(map[string][]byte),
+	}
+	fakeSecret.Data["fake"] = []byte("dummy")
+	objs := []runtime.Object{fakeSecret}
+	mocks := testutils.NewTestMock(t, objs)
+
+	s, e := GetCliSecret(mocks.FakeKubeClient, "fake-name", "sut-ns")
+	if e != nil {
+		t.Errorf("secret should have been retrieved: %w", e)
+	}
+	value := string(s.Data["fake"])
+	if value != "dummy" {
+		t.Errorf("secret doesn't have the data")
 	}
 }


### PR DESCRIPTION
This PR contains a small number of refactoring items:

- defer `panic()` to outer of the context so we can carry the errors and then remove the panic completely then putting a proper error handling. (only applied for aws)
-  migrate _GetSecrets_ that being used during initialization of the clients to _utils_ and enchant with tests
-  remove sts ruins as it's not being actively used. (? not being sure)
-  add small unit tests to the creation of the client