### PR TITLE
fix: change the port so metrics can be served from 8181(as is)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,8 +39,9 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	osdMetricsPort = "8181"
-	osdMetricsPath = "/metrics"
+	osdMetricsPort    = "8181"
+	osdMetricsPath    = "/metrics"
+	livenessProbePort = "8000"
 )
 var log = logf.Log.WithName("cmd")
 
@@ -95,7 +96,7 @@ func main() {
 	}
 
 	options := manager.Options{
-		HealthProbeBindAddress: ":" + osdMetricsPort,
+		HealthProbeBindAddress: ":" + livenessProbePort,
 		Namespace:              namespace,
 	}
 

--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -52,6 +52,6 @@ spec:
             httpGet:
               path: /healthz
               scheme: HTTP
-              port: 8181
+              port: 8000
             initialDelaySeconds: 25
             periodSeconds: 15


### PR DESCRIPTION
This to be fixing the errors below:
(happening due to 8181 is being used by healthz so metrics can't be initialized)

I must have missed this due to running cio on local not inside the pod causing the metrics part to be ignored.

`{"level":"info","ts":1630571129.965603,"logger":"userMetrics","msg":"Port: 8181"}
{"level":"info","ts":1630571129.9656496,"logger":"userMetrics","msg":"Error starting metrics server ","Error":"port 8181 is not free"}
{"level":"error","ts":1630571129.9656594,"logger":"cmd","msg":"Failed to configure OSD metrics","error":"port 8181 is not free","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132\nsigs.k8s.io/controller-runtime/pkg/log.(*DelegatingLogger).Error\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/log/deleg.go:144\nmain.addMetrics\n\t/workdir/cmd/manager/main.go:190\nmain.main\n\t/workdir/cmd/manager/main.go:159\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:225"}
`

tests:
```shell
curl localhost:8000/healthz
ok
```