### PR TITLE
apply client healthchecking options

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -127,10 +127,10 @@ func main() {
 			return err
 		}
 		cloudClient := cloudclient.GetClientFor(cli, *cloudPlatform)
-		err = cloudClient.Healthcheck(context.TODO())
+		err = cloudClient.Healthcheck(context.TODO(), cli)
 		return err
 	}); err != nil {
-		log.Error(err, "unable to set up health check")
+		log.Error(err, "failed to add healthcheck function to mgr")
 		os.Exit(1)
 	}
 

--- a/pkg/cloudclient/add_aws.go
+++ b/pkg/cloudclient/add_aws.go
@@ -8,11 +8,11 @@ import (
 func init() {
 	Register(
 		aws.ClientIdentifier,
-		produce,
+		produceAWS,
 	)
 }
 
-func produce(kclient client.Client) CloudClient {
+func produceAWS(kclient client.Client) CloudClient {
 	cli, err := aws.NewClient(kclient)
 	if err != nil {
 		panic(err)

--- a/pkg/cloudclient/add_aws.go
+++ b/pkg/cloudclient/add_aws.go
@@ -8,6 +8,15 @@ import (
 func init() {
 	Register(
 		aws.ClientIdentifier,
-		func(kclient client.Client) CloudClient { return aws.NewClient(kclient) },
+		produce,
 	)
+}
+
+func produce(kclient client.Client) CloudClient {
+	cli, err := aws.NewClient(kclient)
+	if err != nil {
+		panic(err)
+	}
+
+	return cli
 }

--- a/pkg/cloudclient/add_aws_test.go
+++ b/pkg/cloudclient/add_aws_test.go
@@ -1,0 +1,55 @@
+package cloudclient
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cloud-ingress-operator/config"
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestProducePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("testing panic: should have been failed")
+		}
+	}()
+	objs := []runtime.Object{}
+	mocks := testutils.NewTestMock(t, objs)
+	_ = produce(mocks.FakeKubeClient)
+}
+
+func TestProduceSuccess(t *testing.T) {
+	infra := &configv1.Infrastructure{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				AWS: &configv1.AWSPlatformStatus{
+					Region: "eu-west-1",
+				},
+			},
+		}}
+
+	fakeSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      config.AWSSecretName,
+			Namespace: config.OperatorNamespace,
+		},
+		Data: make(map[string][]byte),
+	}
+	fakeSecret.Data["aws_access_key_id"] = []byte("dummyID")
+	fakeSecret.Data["aws_secret_access_key"] = []byte("dummyPassKey")
+
+	objs := []runtime.Object{infra, fakeSecret}
+	mocks := testutils.NewTestMock(t, objs)
+	cli := produce(mocks.FakeKubeClient)
+	if cli == nil {
+		t.Error("cli couldn't initialize with given params")
+	}
+}

--- a/pkg/cloudclient/add_aws_test.go
+++ b/pkg/cloudclient/add_aws_test.go
@@ -3,11 +3,7 @@ package cloudclient
 import (
 	"testing"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -20,36 +16,4 @@ func TestProduceAWSPanics(t *testing.T) {
 	objs := []runtime.Object{}
 	mocks := testutils.NewTestMock(t, objs)
 	_ = produceAWS(mocks.FakeKubeClient)
-}
-
-func TestProduceAWSSuccess(t *testing.T) {
-	infra := &configv1.Infrastructure{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "cluster",
-			Namespace: "",
-		},
-		Status: configv1.InfrastructureStatus{
-			PlatformStatus: &configv1.PlatformStatus{
-				AWS: &configv1.AWSPlatformStatus{
-					Region: "eu-west-1",
-				},
-			},
-		}}
-
-	fakeSecret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      config.AWSSecretName,
-			Namespace: config.OperatorNamespace,
-		},
-		Data: make(map[string][]byte),
-	}
-	fakeSecret.Data["aws_access_key_id"] = []byte("dummyID")
-	fakeSecret.Data["aws_secret_access_key"] = []byte("dummyPassKey")
-
-	objs := []runtime.Object{infra, fakeSecret}
-	mocks := testutils.NewTestMock(t, objs)
-	cli := produceAWS(mocks.FakeKubeClient)
-	if cli == nil {
-		t.Error("cli couldn't initialize with given params")
-	}
 }

--- a/pkg/cloudclient/add_aws_test.go
+++ b/pkg/cloudclient/add_aws_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestProducePanics(t *testing.T) {
+func TestProduceAWSPanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("testing panic: should have been failed")
@@ -19,10 +19,10 @@ func TestProducePanics(t *testing.T) {
 	}()
 	objs := []runtime.Object{}
 	mocks := testutils.NewTestMock(t, objs)
-	_ = produce(mocks.FakeKubeClient)
+	_ = produceAWS(mocks.FakeKubeClient)
 }
 
-func TestProduceSuccess(t *testing.T) {
+func TestProduceAWSSuccess(t *testing.T) {
 	infra := &configv1.Infrastructure{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "cluster",
@@ -48,7 +48,7 @@ func TestProduceSuccess(t *testing.T) {
 
 	objs := []runtime.Object{infra, fakeSecret}
 	mocks := testutils.NewTestMock(t, objs)
-	cli := produce(mocks.FakeKubeClient)
+	cli := produceAWS(mocks.FakeKubeClient)
 	if cli == nil {
 		t.Error("cli couldn't initialize with given params")
 	}

--- a/pkg/cloudclient/add_gcp.go
+++ b/pkg/cloudclient/add_gcp.go
@@ -8,6 +8,15 @@ import (
 func init() {
 	Register(
 		gcp.ClientIdentifier,
-		func(kclient client.Client) CloudClient { return gcp.NewClient(kclient) },
+		produceGCP,
 	)
+}
+
+func produceGCP(kclient client.Client) CloudClient {
+	cli, err := gcp.NewClient(kclient)
+	if err != nil {
+		panic(err)
+	}
+
+	return cli
 }

--- a/pkg/cloudclient/add_gcp_test.go
+++ b/pkg/cloudclient/add_gcp_test.go
@@ -1,0 +1,19 @@
+package cloudclient
+
+import (
+	"testing"
+
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestProducePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("testing panic: should have been failed")
+		}
+	}()
+	objs := []runtime.Object{}
+	mocks := testutils.NewTestMock(t, objs)
+	_ = produceGCP(mocks.FakeKubeClient)
+}

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -119,10 +119,10 @@ func newClient(accessID, accessSecret, token, region string) (*Client, error) {
 }
 
 // NewClient creates a new CloudClient for use with AWS.
-func NewClient(kclient client.Client) *Client {
+func NewClient(kclient client.Client) (*Client, error) {
 	region, err := getClusterRegion(kclient)
 	if err != nil {
-		panic(fmt.Sprintf("Couldn't get cluster region %s", err.Error()))
+		return nil, fmt.Errorf("couldn't get cluster region %w", err)
 	}
 	secret := &corev1.Secret{}
 	err = kclient.Get(
@@ -133,15 +133,15 @@ func NewClient(kclient client.Client) *Client {
 		},
 		secret)
 	if err != nil {
-		panic(fmt.Sprintf("Couldn't get Secret with credentials %s", err.Error()))
+		return nil, fmt.Errorf("couldn't get Secret with credentials %w", err)
 	}
 	accessKeyID, ok := secret.Data["aws_access_key_id"]
 	if !ok {
-		panic("Access credentials missing key")
+		return nil, fmt.Errorf("access credentials missing key")
 	}
 	secretAccessKey, ok := secret.Data["aws_secret_access_key"]
 	if !ok {
-		panic("Access credentials missing secret key")
+		return nil, fmt.Errorf("access credentials missing secret key")
 	}
 
 	c, err := newClient(
@@ -151,8 +151,8 @@ func NewClient(kclient client.Client) *Client {
 		region)
 
 	if err != nil {
-		panic(fmt.Sprintf("Couldn't create AWS client %s", err.Error()))
+		return nil, fmt.Errorf("couldn't create AWS client %w", err)
 	}
 
-	return c
+	return c, nil
 }

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -26,7 +26,8 @@ func TestNewClient(t *testing.T) {
 					Region: "eu-west-1",
 				},
 			},
-		}}
+		},
+	}
 
 	fakeSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -43,7 +44,7 @@ func TestNewClient(t *testing.T) {
 	cli, err := NewClient(mocks.FakeKubeClient)
 
 	if err != nil {
-		t.Error("err occured while creating cli: %w", err)
+		t.Error("err occured while creating cli:", err)
 	}
 
 	if cli == nil {
@@ -90,7 +91,7 @@ func TestHealthcheck(t *testing.T) {
 	cli := Client{elbClient: &mockELBClient{}}
 	err := cli.Healthcheck(context.TODO(), mocks.FakeKubeClient)
 	if err != nil {
-		t.Errorf("err occured while performing healthcheck: %s", err)
+		t.Error("err occured while performing healthcheck:", err)
 	}
 
 }

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -1,0 +1,96 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cloud-ingress-operator/config"
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestNewClient(t *testing.T) {
+	infra := &configv1.Infrastructure{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				AWS: &configv1.AWSPlatformStatus{
+					Region: "eu-west-1",
+				},
+			},
+		}}
+
+	fakeSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      config.AWSSecretName,
+			Namespace: config.OperatorNamespace,
+		},
+		Data: make(map[string][]byte),
+	}
+	fakeSecret.Data["aws_access_key_id"] = []byte("dummyID")
+	fakeSecret.Data["aws_secret_access_key"] = []byte("dummyPassKey")
+
+	objs := []runtime.Object{infra, fakeSecret}
+	mocks := testutils.NewTestMock(t, objs)
+	cli, err := NewClient(mocks.FakeKubeClient)
+
+	if err != nil {
+		t.Error("err occured while creating cli: %w", err)
+	}
+
+	if cli == nil {
+		t.Errorf("cli should have been initialized")
+	}
+}
+
+type mockELBClient struct {
+	elbiface.ELBAPI
+}
+
+func (m *mockELBClient) DescribeLoadBalancers(i *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+	// mock response/functionality
+	testLB := "test"
+	return &elb.DescribeLoadBalancersOutput{
+		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
+			{
+				LoadBalancerName: &testLB,
+			},
+		},
+	}, nil
+}
+
+func (m *mockELBClient) DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {
+	k := "sut"
+	v := "openshift-kube-apiserver/rh-api"
+	return &elb.DescribeTagsOutput{
+		TagDescriptions: []*elb.TagDescription{
+			{
+				Tags: []*elb.Tag{
+					{
+						Key:   &k,
+						Value: &v,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestHealthcheck(t *testing.T) {
+	objs := []runtime.Object{}
+	mocks := testutils.NewTestMock(t, objs)
+	cli := Client{elbClient: &mockELBClient{}}
+	err := cli.Healthcheck(context.TODO(), mocks.FakeKubeClient)
+	if err != nil {
+		t.Errorf("err occured while performing healthcheck: %s", err)
+	}
+
+}

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -141,10 +141,6 @@ func updateAWSLBList(kclient client.Client, oldLBList []awsproviderapi.LoadBalan
 	return nil
 }
 
-func (c *Client) Healthcheck(ctx context.Context) error {
-	return c.healthcheck()
-}
-
 // ensureAdminAPIDNS ensure the DNS record for the rh-api "admin API" for
 // APIScheme is present and mapped to the corresponding Service's AWS
 // LoadBalancer
@@ -1071,9 +1067,4 @@ func (c *Client) getTargetGroupArn(targetGroupName string) (string, error) {
 		return "", err
 	}
 	return aws.StringValue(result.TargetGroups[0].TargetGroupArn), nil
-}
-
-func (c *Client) healthcheck() error {
-	_, err := c.elbClient.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
-	return err
 }

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -141,6 +141,10 @@ func updateAWSLBList(kclient client.Client, oldLBList []awsproviderapi.LoadBalan
 	return nil
 }
 
+func (c *Client) Healthcheck(ctx context.Context) error {
+	return c.healthcheck()
+}
+
 // ensureAdminAPIDNS ensure the DNS record for the rh-api "admin API" for
 // APIScheme is present and mapped to the corresponding Service's AWS
 // LoadBalancer
@@ -1067,4 +1071,13 @@ func (c *Client) getTargetGroupArn(targetGroupName string) (string, error) {
 		return "", err
 	}
 	return aws.StringValue(result.TargetGroups[0].TargetGroupArn), nil
+}
+
+func (c *Client) healthcheck() error {
+	_, err := c.elbClient.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -1075,9 +1075,5 @@ func (c *Client) getTargetGroupArn(targetGroupName string) (string, error) {
 
 func (c *Client) healthcheck() error {
 	_, err := c.elbClient.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -38,7 +38,7 @@ type CloudClient interface {
 	SetDefaultAPIPublic(context.Context, client.Client, *cloudingressv1alpha1.PublishingStrategy) error
 
 	// Perform healthcheck
-	Healthcheck(context.Context) error
+	Healthcheck(context.Context, client.Client) error
 }
 
 var controllerMapping = map[configv1.PlatformType]Factory{}

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -12,6 +12,7 @@ import (
 )
 
 // CloudClient defines the interface for a cloud agnostic implementation
+// For mocking: mockgen -source=pkg/cloudclient/cloudclient.go -destination=pkg/cloudclient/mock_cloudclient/mock_cloudclient.go
 type CloudClient interface {
 
 	/* APIScheme */
@@ -35,6 +36,9 @@ type CloudClient interface {
 
 	// SetDefaultAPIPublic ensures that the default API is public, per user configure
 	SetDefaultAPIPublic(context.Context, client.Client, *cloudingressv1alpha1.PublishingStrategy) error
+
+	// Perform healthcheck
+	Healthcheck(context.Context) error
 }
 
 var controllerMapping = map[configv1.PlatformType]Factory{}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -76,9 +76,13 @@ func (c *Client) Healthcheck(ctx context.Context, kclient client.Client) error {
 		return err // possible client deformation
 	}
 
-	// checking rh-api to ensure it's there and available to use by cloud-client
-	intLBName := c.clusterName + "-api-internal"
-	for _, lb := range out.Items {
+	return performHealthCheck(out, c.clusterName)
+}
+
+func performHealthCheck(l *computev1.BackendServiceList, clusterName string) error {
+	// checking internal lb to ensure it's there and available to use by cloud-client
+	intLBName := clusterName + "-api-internal"
+	for _, lb := range l.Items {
 		if lb.Name == intLBName {
 			return nil
 		}

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -6,6 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	computev1 "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,7 +35,8 @@ func TestNewClient(t *testing.T) {
 					Region: "eu-west-1",
 				},
 			},
-		}}
+		},
+	}
 
 	fakeSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -50,10 +52,26 @@ func TestNewClient(t *testing.T) {
 	cli, err := NewClient(mocks.FakeKubeClient)
 
 	if err != nil {
-		t.Error("err occured while creating cli: %w", err)
+		t.Error("err occured while creating cli:", err)
 	}
 
 	if cli == nil {
-		t.Errorf("cli should have been initialized")
+		t.Error("cli should have been initialized")
+	}
+}
+
+// testing only performHealthCheck
+// mocking c.computeService.RegionBackendServices.List(c.projectID, c.region).Do() is hard coz they're not bound to an interface
+func TestPerformHealthCheck(t *testing.T) {
+	l := &computev1.BackendServiceList{
+		Items: []*computev1.BackendService{
+			{
+				Name: "test-api-internal",
+			},
+		}}
+
+	err := performHealthCheck(l, "test")
+	if err != nil {
+		t.Error("tests shouldn't have failed:", err)
 	}
 }

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -1,0 +1,59 @@
+package gcp
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cloud-ingress-operator/config"
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestNewClient(t *testing.T) {
+	dummySA := `{
+		"type": "service_account",
+		"private_key_id": "abc",
+		"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAKECBKgwggSkAgEAAoIBAQDY3E8o1NEFcjFAKEHW/5ZfFJw29/8NEqpViNjQIx95Xx5KDtJ+nWFAKEW0uqsSqKlKGhAdAo+Q6bjx2cFAKEVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd/yHuONQn/rIAieTHH1pqgW+zrH/y3c\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+/Eovn\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+/\n/uLQUcL7I55Dxn7KUoZs/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\nChbdkkTRLnbsRr0Yg/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\nznUhDVxPFBuxyUHtsJNqW4p/ujLNimGet5E/YthCnQeC2P3Ym7c3fiz68amM6hiA\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\nyfH12UWqVmFSHsgZFqM/cK3wGev38h1WBIOx3/djKn7BdlKVh8kWyx6uC8bmV+E6\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa/hVW\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+/zrDMDCPiSLX1NAvAoGBAN1T\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\nqmT8YYGu76/IBWUSqWuvcpHPpwl7871i4Ga/I3qnAoGBANNkKAcMoeAbJQK7a/Rn\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX/gQarcjRcXXZeEa\nNtBLSfcqPULqD+h7br9lEJio\n-----END PRIVATE KEY-----\n",
+		"client_email": "123-abc@developer.gserviceaccount.com",
+		"client_id": "123-abc.apps.googleusercontent.com",
+		"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+		"token_uri": "http://localhost:8080/token"
+	  }`
+
+	infra := &configv1.Infrastructure{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "",
+		},
+		Status: configv1.InfrastructureStatus{
+			APIServerURL: "https://api.dummy.fsrl.s1.testing.org:6443",
+			PlatformStatus: &configv1.PlatformStatus{
+				GCP: &configv1.GCPPlatformStatus{
+					Region: "eu-west-1",
+				},
+			},
+		}}
+
+	fakeSecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      config.GCPSecretName,
+			Namespace: config.OperatorNamespace,
+		},
+		Data: make(map[string][]byte),
+	}
+	fakeSecret.Data["service_account.json"] = []byte(dummySA)
+
+	objs := []runtime.Object{infra, fakeSecret}
+	mocks := testutils.NewTestMock(t, objs)
+	cli, err := NewClient(mocks.FakeKubeClient)
+
+	if err != nil {
+		t.Error("err occured while creating cli: %w", err)
+	}
+
+	if cli == nil {
+		t.Errorf("cli should have been initialized")
+	}
+}

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -559,7 +559,6 @@ func getClusterDNS(kclient client.Client) (*configv1.DNS, error) {
 }
 
 func (c *Client) healthcheck() error {
-	healthCheckCall := c.computeService.ForwardingRules.List(c.projectID, "us-west-1") // check a random region to check cloud client availability.
-	_, err := healthCheckCall.Do()
+	_, err := c.computeService.BackendServices.List(c.projectID).Do() // checking backend services to ensure cloud client availability.
 	return err
 }

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -29,6 +29,10 @@ import (
 	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
 )
 
+func (c *Client) Healthcheck(ctx context.Context) error {
+	return c.healthcheck()
+}
+
 // ensureAdminAPIDNS ensures the DNS record for the "admin API" Service
 // LoadBalancer is accurately set
 func (c *Client) ensureAdminAPIDNS(ctx context.Context, kclient client.Client, instance *cloudingressv1alpha1.APIScheme, svc *corev1.Service) error {
@@ -552,4 +556,14 @@ func getClusterDNS(kclient client.Client) (*configv1.DNS, error) {
 	}
 
 	return dns, nil
+}
+
+func (c *Client) healthcheck() error {
+	healthCheckCall := c.computeService.ForwardingRules.List(c.projectID, "us-west-1") // check a random region to check cloud client availability.
+	_, err := healthCheckCall.Do()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -561,9 +561,5 @@ func getClusterDNS(kclient client.Client) (*configv1.DNS, error) {
 func (c *Client) healthcheck() error {
 	healthCheckCall := c.computeService.ForwardingRules.List(c.projectID, "us-west-1") // check a random region to check cloud client availability.
 	_, err := healthCheckCall.Do()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/pkg/cloudclient/mock_cloudclient/mock_cloudclient.go
+++ b/pkg/cloudclient/mock_cloudclient/mock_cloudclient.go
@@ -94,17 +94,17 @@ func (mr *MockCloudClientMockRecorder) EnsureSSHDNS(arg0, arg1, arg2, arg3 inter
 }
 
 // Healthcheck mocks base method.
-func (m *MockCloudClient) Healthcheck(arg0 context.Context) error {
+func (m *MockCloudClient) Healthcheck(arg0 context.Context, arg1 client.Client) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Healthcheck", arg0)
+	ret := m.ctrl.Call(m, "Healthcheck", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Healthcheck indicates an expected call of Healthcheck.
-func (mr *MockCloudClientMockRecorder) Healthcheck(arg0 interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) Healthcheck(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthcheck", reflect.TypeOf((*MockCloudClient)(nil).Healthcheck), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthcheck", reflect.TypeOf((*MockCloudClient)(nil).Healthcheck), arg0, arg1)
 }
 
 // SetDefaultAPIPrivate mocks base method.

--- a/pkg/cloudclient/mock_cloudclient/mock_cloudclient.go
+++ b/pkg/cloudclient/mock_cloudclient/mock_cloudclient.go
@@ -6,51 +6,38 @@ package mock_cloudclient
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	reflect "reflect"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockCloudClient is a mock of CloudClient interface
+// MockCloudClient is a mock of CloudClient interface.
 type MockCloudClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockCloudClientMockRecorder
 }
 
-// MockCloudClientMockRecorder is the mock recorder for MockCloudClient
+// MockCloudClientMockRecorder is the mock recorder for MockCloudClient.
 type MockCloudClientMockRecorder struct {
 	mock *MockCloudClient
 }
 
-// NewMockCloudClient creates a new mock instance
+// NewMockCloudClient creates a new mock instance.
 func NewMockCloudClient(ctrl *gomock.Controller) *MockCloudClient {
 	mock := &MockCloudClient{ctrl: ctrl}
 	mock.recorder = &MockCloudClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 	return m.recorder
 }
 
-// EnsureAdminAPIDNS mocks base method
-func (m *MockCloudClient) EnsureAdminAPIDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.APIScheme, arg3 *v1.Service) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureAdminAPIDNS", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureAdminAPIDNS indicates an expected call of EnsureAdminAPIDNS
-func (mr *MockCloudClientMockRecorder) EnsureAdminAPIDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdminAPIDNS", reflect.TypeOf((*MockCloudClient)(nil).EnsureAdminAPIDNS), arg0, arg1, arg2, arg3)
-}
-
-// DeleteAdminAPIDNS mocks base method
+// DeleteAdminAPIDNS mocks base method.
 func (m *MockCloudClient) DeleteAdminAPIDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.APIScheme, arg3 *v1.Service) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAdminAPIDNS", arg0, arg1, arg2, arg3)
@@ -58,27 +45,13 @@ func (m *MockCloudClient) DeleteAdminAPIDNS(arg0 context.Context, arg1 client.Cl
 	return ret0
 }
 
-// DeleteAdminAPIDNS indicates an expected call of DeleteAdminAPIDNS
+// DeleteAdminAPIDNS indicates an expected call of DeleteAdminAPIDNS.
 func (mr *MockCloudClientMockRecorder) DeleteAdminAPIDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAdminAPIDNS", reflect.TypeOf((*MockCloudClient)(nil).DeleteAdminAPIDNS), arg0, arg1, arg2, arg3)
 }
 
-// EnsureSSHDNS mocks base method
-func (m *MockCloudClient) EnsureSSHDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.SSHD, arg3 *v1.Service) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureSSHDNS", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// EnsureSSHDNS indicates an expected call of EnsureSSHDNS
-func (mr *MockCloudClientMockRecorder) EnsureSSHDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSSHDNS", reflect.TypeOf((*MockCloudClient)(nil).EnsureSSHDNS), arg0, arg1, arg2, arg3)
-}
-
-// DeleteSSHDNS mocks base method
+// DeleteSSHDNS mocks base method.
 func (m *MockCloudClient) DeleteSSHDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.SSHD, arg3 *v1.Service) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSSHDNS", arg0, arg1, arg2, arg3)
@@ -86,13 +59,55 @@ func (m *MockCloudClient) DeleteSSHDNS(arg0 context.Context, arg1 client.Client,
 	return ret0
 }
 
-// DeleteSSHDNS indicates an expected call of DeleteSSHDNS
+// DeleteSSHDNS indicates an expected call of DeleteSSHDNS.
 func (mr *MockCloudClientMockRecorder) DeleteSSHDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSSHDNS", reflect.TypeOf((*MockCloudClient)(nil).DeleteSSHDNS), arg0, arg1, arg2, arg3)
 }
 
-// SetDefaultAPIPrivate mocks base method
+// EnsureAdminAPIDNS mocks base method.
+func (m *MockCloudClient) EnsureAdminAPIDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.APIScheme, arg3 *v1.Service) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureAdminAPIDNS", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureAdminAPIDNS indicates an expected call of EnsureAdminAPIDNS.
+func (mr *MockCloudClientMockRecorder) EnsureAdminAPIDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdminAPIDNS", reflect.TypeOf((*MockCloudClient)(nil).EnsureAdminAPIDNS), arg0, arg1, arg2, arg3)
+}
+
+// EnsureSSHDNS mocks base method.
+func (m *MockCloudClient) EnsureSSHDNS(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.SSHD, arg3 *v1.Service) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureSSHDNS", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureSSHDNS indicates an expected call of EnsureSSHDNS.
+func (mr *MockCloudClientMockRecorder) EnsureSSHDNS(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSSHDNS", reflect.TypeOf((*MockCloudClient)(nil).EnsureSSHDNS), arg0, arg1, arg2, arg3)
+}
+
+// Healthcheck mocks base method.
+func (m *MockCloudClient) Healthcheck(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Healthcheck", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Healthcheck indicates an expected call of Healthcheck.
+func (mr *MockCloudClientMockRecorder) Healthcheck(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Healthcheck", reflect.TypeOf((*MockCloudClient)(nil).Healthcheck), arg0)
+}
+
+// SetDefaultAPIPrivate mocks base method.
 func (m *MockCloudClient) SetDefaultAPIPrivate(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.PublishingStrategy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDefaultAPIPrivate", arg0, arg1, arg2)
@@ -100,13 +115,13 @@ func (m *MockCloudClient) SetDefaultAPIPrivate(arg0 context.Context, arg1 client
 	return ret0
 }
 
-// SetDefaultAPIPrivate indicates an expected call of SetDefaultAPIPrivate
+// SetDefaultAPIPrivate indicates an expected call of SetDefaultAPIPrivate.
 func (mr *MockCloudClientMockRecorder) SetDefaultAPIPrivate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultAPIPrivate", reflect.TypeOf((*MockCloudClient)(nil).SetDefaultAPIPrivate), arg0, arg1, arg2)
 }
 
-// SetDefaultAPIPublic mocks base method
+// SetDefaultAPIPublic mocks base method.
 func (m *MockCloudClient) SetDefaultAPIPublic(arg0 context.Context, arg1 client.Client, arg2 *v1alpha1.PublishingStrategy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDefaultAPIPublic", arg0, arg1, arg2)
@@ -114,7 +129,7 @@ func (m *MockCloudClient) SetDefaultAPIPublic(arg0 context.Context, arg1 client.
 	return ret0
 }
 
-// SetDefaultAPIPublic indicates an expected call of SetDefaultAPIPublic
+// SetDefaultAPIPublic indicates an expected call of SetDefaultAPIPublic.
 func (mr *MockCloudClientMockRecorder) SetDefaultAPIPublic(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultAPIPublic", reflect.TypeOf((*MockCloudClient)(nil).SetDefaultAPIPublic), arg0, arg1, arg2)


### PR DESCRIPTION
this adds basic calls to healthchecking for cloudclient. 
the calls can go from straightforward to complex depending on which items is enough to be checked

Tests against AWS cluster:

```shell
curl localhost:8000/healthz
ok
```

Tests against GCP cluster:

```shell
curl localhost:8000/healthz
ok
```

If healthcheck fails, it won't cause the main to be exited instead just returns an http code other than 200 and indirectly causes it to be killed by k8s
```shell
{"level":"info","ts":1633004752.2862713,"logger":"controller-runtime.healthz","msg":"healthz check failed","statuses":[{}]}
```