### PR TITLE
fix: remove dependency to env variables using aws client

### DIFF
--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -99,13 +98,7 @@ func (c *Client) Healthcheck(ctx context.Context, kclient client.Client) error {
 }
 
 func newClient(accessID, accessSecret, token, region string) (*Client, error) {
-	awsConfig := &aws.Config{Region: aws.String(region)}
-	if token == "" {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessID)
-		os.Setenv("AWS_SECRET_ACCESS_KEY", accessSecret)
-	} else {
-		awsConfig.Credentials = credentials.NewStaticCredentials(accessID, accessSecret, token)
-	}
+	awsConfig := &aws.Config{Region: aws.String(region), Credentials: credentials.NewStaticCredentials(accessID, accessSecret, token)}
 	s, err := session.NewSession(awsConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pre-note:
_NewStaticCredentials returns a pointer to a new Credentials object wrapping a static credentials value provider. Token is only required for temporary security credentials retrieved via STS, otherwise an empty string can be passed for this parameter._

This removes the envvar dependency fixes the following errs:

```shell
{"level":"error","ts":1633525392.125891,"logger":"controller_publishingstrategy","msg":"Error updating api.xxx-test.qx0s.s1.devshift.org alias to external NLB","error":"InvalidClientTokenId: The security token included in the request is invalid\n\tstatus code: 403
```

to

```shell
{"level":"info","ts":1633529655.5695589,"logger":"controller_publishingstrategy","msg":"Update api.xxx-test.qx0s.s1.devshift.org alias to external NLB successful"}
```