### PR TITLE
feat: add k8s call to healthcheck

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -8,6 +8,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 
+	operv1 "github.com/openshift/api/operator/v1"
 	gcpproviderapi "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,6 +103,9 @@ func NewTestMock(t *testing.T, localObjs []runtime.Object) *Mocks {
 	}
 	if err := cloudingressv1alpha1.SchemeBuilder.AddToScheme(s); err != nil {
 		t.Fatalf("Couldn't add cloudingressv1alpha1 scheme: (%v)", err)
+	}
+	if err := operv1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add route scheme: (%v)", err)
 	}
 	ret := &Mocks{
 		FakeKubeClient: fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(localObjs...).Build(),

--- a/pkg/utils/healthcheck.go
+++ b/pkg/utils/healthcheck.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"context"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SAhealthcheck will perform a basic call to make sure ingresscontrollers is reachable
+// covers: https://github.com/openshift/cloud-ingress-operator/blob/32e50ef2aa8571f9bb60aaf53ed9d1262cc2c083/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml#L39-L50
+func SAhealthcheck(kclient client.Client) error {
+	var op operv1.IngressController
+	ns := types.NamespacedName{
+		Namespace: "openshift-ingress-operator",
+		Name:      "default",
+	}
+	return kclient.Get(context.TODO(), ns, &op)
+}

--- a/pkg/utils/healthcheck_test.go
+++ b/pkg/utils/healthcheck_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"testing"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestSAhealthcheck(t *testing.T) {
+	ingressCO := &operv1.IngressController{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+	}
+	objs := []runtime.Object{ingressCO}
+	mocks := testutils.NewTestMock(t, objs)
+	if err := SAhealthcheck(mocks.FakeKubeClient); err != nil {
+		t.Error("checking ingresscontroller failed:", err)
+	}
+}


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OSD-7407

the resource that's checked: https://github.com/openshift/cloud-ingress-operator/blob/32e50ef2aa8571f9bb60aaf53ed9d1262cc2c083/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml#L39-L50