### PR TITLE
Limited RBAC for namespaced roles and added required roles to the SSS that can't be deployed by the bundle

### DIFF
--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -1,9 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
-  namespace: openshift-cloud-ingress-operator
 rules:
 - apiGroups:
   - config.openshift.io

--- a/deploy/20_cloud-ingress-operator.Role.yaml
+++ b/deploy/20_cloud-ingress-operator.Role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
   namespace: openshift-cloud-ingress-operator
 rules:

--- a/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
@@ -1,53 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
   namespace: openshift-kube-apiserver
 rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
   - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cloudingress.managed.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch

--- a/deploy/20_cloud-ingress-operator_kube-apiserver.RoleBinding.yaml
+++ b/deploy/20_cloud-ingress-operator_kube-apiserver.RoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: cloud-ingress-operator
   namespace: openshift-kube-apiserver

--- a/deploy/20_cloud-ingress-operator_machine.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_machine.Role.yaml
@@ -1,64 +1,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
   namespace: openshift-machine-api
 rules:
 - apiGroups:
   - machine.openshift.io
   resources:
-    - machines
-    - machinesets
+  - machines
+  - machinesets
   verbs:
-    - get
-    - list
-    - watch
-    - patch
-    - update
+  - get
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cloudingress.managed.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch

--- a/deploy/20_cloud-ingress-operator_machine.RoleBinding.yaml
+++ b/deploy/20_cloud-ingress-operator_machine.RoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: cloud-ingress-operator
   namespace: openshift-machine-api

--- a/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml
@@ -1,65 +1,34 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
   namespace: openshift-ingress-operator
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cloudingress.managed.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - operator.openshift.io
   resources:
-    - ingresscontrollers
+  - ingresscontrollers
   verbs:
-    - get
-    - list
-    - watch
-    - patch
-    - delete
-    - create
-    - update
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch

--- a/deploy/20_cloud-ingress-operator_openshift-ingress-operator.RoleBinding.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress-operator.RoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: cloud-ingress-operator
   namespace: openshift-ingress-operator

--- a/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
@@ -1,53 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cloud-ingress-operator
   namespace: openshift-ingress
 rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - services
   - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cloudingress.managed.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch

--- a/deploy/20_cloud-ingress-operator_openshift-ingress.RoleBinding.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress.RoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: cloud-ingress-operator
   namespace: openshift-ingress

--- a/deploy/20_cloud-ingress-operator_sshd.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_sshd.Role.yaml
@@ -1,29 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
-  name: cloud-ingress-operator
+  name: cloud-ingress-operator  
   namespace: openshift-sre-sshd
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - cloudingress.managed.openshift.io
   resources:
@@ -35,6 +15,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - apps

--- a/deploy/20_cloud-ingress-operator_sshd.RoleBinding.yaml
+++ b/deploy/20_cloud-ingress-operator_sshd.RoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: cloud-ingress-operator
   namespace: openshift-sre-sshd

--- a/deploy/25_cloud-ingress-operator.ClusterRoleBinding.yaml
+++ b/deploy/25_cloud-ingress-operator.ClusterRoleBinding.yaml
@@ -1,5 +1,5 @@
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: cloud-ingress-operator
 subjects:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,372 +1,612 @@
-apiVersion: v1
-kind: Template
-parameters:
-- name: REGISTRY_IMG
-  required: true
-- name: CHANNEL
-  required: true
-- name: IMAGE_TAG
-  required: true
-- name: IMAGE_DIGEST
-  requred: true
-- name: REPO_NAME
-  value: cloud-ingress-operator
-  required: true
-- name: DISPLAY_NAME
-  value: Cloud Ingress Operator
-  required: true
-metadata:
-  name: selectorsyncset-template
-objects:
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
+  apiVersion: v1
+  kind: Template
+  parameters:
+  - name: REGISTRY_IMG
+    required: true
+  - name: CHANNEL
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    requred: true
+  - name: REPO_NAME
+    value: cloud-ingress-operator
+    required: true
+  - name: DISPLAY_NAME
+    value: Cloud Ingress Operator
+    required: true
   metadata:
-    annotations:
-      component-display-name: ${DISPLAY_NAME}
-      component-name: ${REPO_NAME}
-      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: cloud-ingress-operator
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/sts
-        operator: NotIn
-        values:
-        - "true"
-      - key: api.openshift.com/private-link
-        operator: NotIn
-        values:
-        - "true"
-    resourceApplyMode: Sync
-    resources:
-    - kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: openshift-cloud-ingress-operator
-        labels:
-          openshift.io/cluster-monitoring: 'true'
-    - apiVersion: cloudcredential.openshift.io/v1
-      kind: CredentialsRequest
-      metadata:
-        name: cloud-ingress-operator-credentials-aws
-        namespace: openshift-cloud-ingress-operator
-      spec:
-        secretRef:
+    name: selectorsyncset-template
+  objects:
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      annotations:
+        component-display-name: ${DISPLAY_NAME}
+        component-name: ${REPO_NAME}
+        telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: 'true'
+      name: cloud-ingress-operator
+    spec:
+      clusterDeploymentSelector:
+        matchLabels:
+          api.openshift.com/managed: 'true'
+        matchExpressions:
+        - key: api.openshift.com/sts
+          operator: NotIn
+          values:
+          - "true"
+        - key: api.openshift.com/private-link
+          operator: NotIn
+          values:
+          - "true"
+      resourceApplyMode: Sync
+      resources:
+      - kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: openshift-cloud-ingress-operator
+          labels:
+            openshift.io/cluster-monitoring: 'true'
+      - apiVersion: cloudcredential.openshift.io/v1
+        kind: CredentialsRequest
+        metadata:
           name: cloud-ingress-operator-credentials-aws
           namespace: openshift-cloud-ingress-operator
-        providerSpec:
-          apiVersion: cloudcredential.openshift.io/v1
-          kind: AWSProviderSpec
-          statementEntries:
-          - effect: Allow
-            resource: '*'
-            action:
-            - elasticloadbalancing:*
-            - ec2:DescribeAccountAttributes
-            - ec2:DescribeAddresses
-            - ec2:DescribeInternetGateways
-            - ec2:DescribeSecurityGroups
-            - ec2:DescribeSubnets
-            - ec2:DescribeVpcs
-            - ec2:DescribeVpcClassicLink
-            - ec2:DescribeInstances
-            - ec2:DescribeNetworkInterfaces
-            - ec2:DescribeClassicLinkInstances
-            - ec2:DescribeRouteTables
-            - ec2:AuthorizeSecurityGroupEgress
-            - ec2:AuthorizeSecurityGroupIngress
-            - ec2:CreateSecurityGroup
-            - ec2:DeleteSecurityGroup
-            - ec2:DescribeInstanceAttribute
-            - ec2:DescribeInstanceStatus
-            - ec2:DescribeNetworkAcls
-            - ec2:DescribeSecurityGroups
-            - ec2:RevokeSecurityGroupEgress
-            - ec2:RevokeSecurityGroupIngress
-            - ec2:DescribeTags
-            - ec2:CreateTags
-            - ec2:DeleteTags
-            - route53:ChangeResourceRecordSets
-            - route53:GetHostedZone
-            - route53:GetHostedZoneCount
-            - route53:ListHostedZones
-            - route53:ListHostedZonesByName
-            - route53:ListResourceRecordSets
-            - route53:UpdateHostedZoneComment
-    - apiVersion: cloudcredential.openshift.io/v1
-      kind: CredentialsRequest
-      metadata:
-        name: cloud-ingress-operator-credentials-gcp
-        namespace: openshift-cloud-ingress-operator
-      spec:
-        secretRef:
+        spec:
+          secretRef:
+            name: cloud-ingress-operator-credentials-aws
+            namespace: openshift-cloud-ingress-operator
+          providerSpec:
+            apiVersion: cloudcredential.openshift.io/v1
+            kind: AWSProviderSpec
+            statementEntries:
+            - effect: Allow
+              resource: '*'
+              action:
+              - elasticloadbalancing:*
+              - ec2:DescribeAccountAttributes
+              - ec2:DescribeAddresses
+              - ec2:DescribeInternetGateways
+              - ec2:DescribeSecurityGroups
+              - ec2:DescribeSubnets
+              - ec2:DescribeVpcs
+              - ec2:DescribeVpcClassicLink
+              - ec2:DescribeInstances
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DescribeClassicLinkInstances
+              - ec2:DescribeRouteTables
+              - ec2:AuthorizeSecurityGroupEgress
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:CreateSecurityGroup
+              - ec2:DeleteSecurityGroup
+              - ec2:DescribeInstanceAttribute
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeNetworkAcls
+              - ec2:DescribeSecurityGroups
+              - ec2:RevokeSecurityGroupEgress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:DescribeTags
+              - ec2:CreateTags
+              - ec2:DeleteTags
+              - route53:ChangeResourceRecordSets
+              - route53:GetHostedZone
+              - route53:GetHostedZoneCount
+              - route53:ListHostedZones
+              - route53:ListHostedZonesByName
+              - route53:ListResourceRecordSets
+              - route53:UpdateHostedZoneComment
+      - apiVersion: cloudcredential.openshift.io/v1
+        kind: CredentialsRequest
+        metadata:
           name: cloud-ingress-operator-credentials-gcp
           namespace: openshift-cloud-ingress-operator
-        providerSpec:
-          apiVersion: cloudcredential.openshift.io/v1
-          kind: GCPProviderSpec
-          predefinedRoles:
-          - roles/dns.admin
-          - roles/compute.networkAdmin
-          skipServiceCheck: true
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        creationTimestamp: null
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      rules:
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machines
-        - machinesets
-        verbs:
-        - get
-        - list
-        - watch
-        - patch
-        - update
-      - apiGroups:
-        - operator.openshift.io
-        resources:
-        - ingresscontrollers
-        verbs:
-        - get
-        - list
-        - watch
-        - patch
-        - delete
-        - create
-        - update
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
-        - apiservers
-        - dnses
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - apiservers
-        verbs:
-        - patch
-        - update
-        - watch
-      - apiGroups:
-        - cloudingress.managed.openshift.io
-        resources:
-        - '*'
-        - apischemes
-        - publishingstrategies
-        verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - services
-        - services/finalizers
-        - endpoints
-        - persistentvolumeclaims
-        - events
-        - configmaps
-        - secrets
-        verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-      - apiGroups:
-        - apps
-        resources:
-        - deployments
-        - daemonsets
-        - replicasets
-        - statefulsets
-        verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-      - apiGroups:
-        - monitoring.coreos.com
-        resources:
-        - servicemonitors
-        verbs:
-        - get
-        - create
-      - apiGroups:
-        - apps
-        resourceNames:
-        - cloud-ingress-operator
-        resources:
-        - deployments/finalizers
-        verbs:
-        - update
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        verbs:
-        - get
-      - apiGroups:
-        - apps
-        resources:
-        - replicasets
-        - deployments
-        verbs:
-        - get
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        creationTimestamp: null
-        name: cluster-config-v1-reader-cio
-        namespace: kube-system
-      rules:
-      - apiGroups:
-        - ''
-        resourceNames:
-        - cluster-config-v1
-        resources:
-        - configmaps
-        verbs:
-        - get
-    - kind: RoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: cloud-ingress-operator-cluster-config-v1-reader
-        namespace: kube-system
-        labels:
-          owner: cloud-ingress-operator
-          owner.namespace: openshift-cloud-ingress-operator
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
+        spec:
+          secretRef:
+            name: cloud-ingress-operator-credentials-gcp
+            namespace: openshift-cloud-ingress-operator
+          providerSpec:
+            apiVersion: cloudcredential.openshift.io/v1
+            kind: GCPProviderSpec
+            predefinedRoles:
+            - roles/dns.admin
+            - roles/compute.networkAdmin
+            skipServiceCheck: true
+      - apiVersion: operators.coreos.com/v1alpha1
+        kind: CatalogSource
+        metadata:
+          labels:
+            opsrc-datastore: 'true'
+            opsrc-provider: redhat
+          name: ${REPO_NAME}-registry
+          namespace: openshift-${REPO_NAME}
+        spec:
+          image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+          - operator: Exists
+            key: node-role.kubernetes.io/infra
+            effect: NoSchedule
+          displayName: ${REPO_NAME}
+          icon:
+            base64data: ''
+            mediatype: ''
+          publisher: Red Hat
+          sourceType: grpc
+      - apiVersion: operators.coreos.com/v1
+        kind: OperatorGroup
+        metadata:
+          name: ${REPO_NAME}
+          namespace: openshift-${REPO_NAME}
+        spec:
+          targetNamespaces:
+          - openshift-${REPO_NAME}
+      - apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: ${REPO_NAME}
+          namespace: openshift-${REPO_NAME}
+        spec:
+          channel: ${CHANNEL}
+          name: ${REPO_NAME}
+          source: ${REPO_NAME}-registry
+          sourceNamespace: openshift-${REPO_NAME}
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
-        name: cluster-config-v1-reader-cio
-    - kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: cloud-ingress-operator
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
+        metadata:
+          name: cloud-ingress-operator  
+          namespace: openshift-sre-sshd
+        rules:
+        - apiGroups:
+          - cloudingress.managed.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-kube-apiserver
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-sre-sshd
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-ingress-operator
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-ingress-operator
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          creationTimestamp: null
+          name: cluster-config-v1-reader-cio
+          namespace: kube-system
+        rules:
+        - apiGroups:
+          - ""
+          resourceNames:
+          - cluster-config-v1
+          resources:
+          - configmaps
+          verbs:
+          - get
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-machine-api
+        rules:
+        - apiGroups:
+          - machine.openshift.io
+          resources:
+          - machines
+          - machinesets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: prometheus-k8s
+          namespace: openshift-cloud-ingress-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRole
-        name: cloud-ingress-operator
-    - kind: RoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      roleRef:
+        metadata:
+          name: cloud-ingress-operator
+        rules:
+        - apiGroups:
+          - config.openshift.io
+          resources:
+            - infrastructures
+            - apiservers
+            - dnses
+          verbs:
+            - list
+            - get
+            - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - patch
+          - update
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: cloud-ingress-operator
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: cloud-ingress-operator
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: prometheus-k8s
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: prometheus-k8s
+        subjects:
+        - kind: ServiceAccount
+          name: prometheus-k8s
+          namespace: openshift-monitoring
+      - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-        apiGroup: rbac.authorization.k8s.io
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        name: prometheus-k8s
-        namespace: openshift-cloud-ingress-operator
-      rules:
-      - apiGroups:
-        - ''
-        resources:
-        - services
-        - endpoints
-        - pods
-        verbs:
-        - get
-        - list
-        - watch
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: prometheus-k8s
-        namespace: openshift-cloud-ingress-operator
-      roleRef:
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        rules:
+        - apiGroups:
+          - cloudingress.managed.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - cloud-ingress-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator-cluster-config-v1-reader
+          namespace: kube-system
+          labels:
+            owner: cloud-ingress-operator
+            owner.namespace: openshift-cloud-ingress-operator
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: cluster-config-v1-reader-cio
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-sre-sshd
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-sre-sshd
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-sre-sshd
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-sre-sshd
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-ingress
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-ingress
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-machine-api
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-machine-api
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-kube-apiserver
+        subjects:
+        - kind: ServiceAccount
+          name: cloud-ingress-operator
+          namespace: openshift-cloud-ingress-operator
+        roleRef:
+          kind: Role
+          name: cloud-ingress-operator
+          namespace: openshift-kube-apiserver
+          apiGroup: rbac.authorization.k8s.io
+      - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
-        name: prometheus-k8s
-      subjects:
-      - kind: ServiceAccount
-        name: prometheus-k8s
-        namespace: openshift-monitoring
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
-        labels:
-          opsrc-datastore: 'true'
-          opsrc-provider: redhat
-        name: ${REPO_NAME}-registry
-        namespace: openshift-${REPO_NAME}
-      spec:
-        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
-        displayName: ${REPO_NAME}
-        icon:
-          base64data: ''
-          mediatype: ''
-        publisher: Red Hat
-        sourceType: grpc
-    - apiVersion: operators.coreos.com/v1
-      kind: OperatorGroup
-      metadata:
-        name: ${REPO_NAME}
-        namespace: openshift-${REPO_NAME}
-      spec:
-        targetNamespaces:
-        - openshift-${REPO_NAME}
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: ${REPO_NAME}
-        namespace: openshift-${REPO_NAME}
-      spec:
-        channel: ${CHANNEL}
-        name: ${REPO_NAME}
-        source: ${REPO_NAME}-registry
-        sourceNamespace: openshift-${REPO_NAME}
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-ingress-operator
+        rules:
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: cloud-ingress-operator
+          namespace: openshift-ingress
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+


### PR DESCRIPTION
This PR solves two problems:
1. Even after the previous RBAC refactor, some of the roles are too permissive and reference resources that CIO never uses. I've rescoped all the roles related to external namespaces from the operators to have the minimal required permissions
2. Not all roles are being deployed in the OLM bundle and there has been a conflict between the SSS and the OLM bundle with the clusterrole. I've added all the roles that are not deployed by the bundle into the SSS and updated the clusterrole definition to match what we expect. 