### PR TITLE
Fix tabbing and remove second definition of the same role

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,612 +1,569 @@
-  apiVersion: v1
-  kind: Template
-  parameters:
-  - name: REGISTRY_IMG
-    required: true
-  - name: CHANNEL
-    required: true
-  - name: IMAGE_TAG
-    required: true
-  - name: IMAGE_DIGEST
-    requred: true
-  - name: REPO_NAME
-    value: cloud-ingress-operator
-    required: true
-  - name: DISPLAY_NAME
-    value: Cloud Ingress Operator
-    required: true
+apiVersion: v1
+kind: Template
+parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: CHANNEL
+  required: true
+- name: IMAGE_TAG
+  required: true
+- name: IMAGE_DIGEST
+  requred: true
+- name: REPO_NAME
+  value: cloud-ingress-operator
+  required: true
+- name: DISPLAY_NAME
+  value: Cloud Ingress Operator
+  required: true
+metadata:
+  name: selectorsyncset-template
+objects:
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
   metadata:
-    name: selectorsyncset-template
-  objects:
-  - apiVersion: hive.openshift.io/v1
-    kind: SelectorSyncSet
-    metadata:
-      annotations:
-        component-display-name: ${DISPLAY_NAME}
-        component-name: ${REPO_NAME}
-        telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
-      labels:
-        managed.openshift.io/gitHash: ${IMAGE_TAG}
-        managed.openshift.io/gitRepoName: ${REPO_NAME}
-        managed.openshift.io/osd: 'true'
-      name: cloud-ingress-operator
-    spec:
-      clusterDeploymentSelector:
-        matchLabels:
-          api.openshift.com/managed: 'true'
-        matchExpressions:
-        - key: api.openshift.com/sts
-          operator: NotIn
-          values:
-          - "true"
-        - key: api.openshift.com/private-link
-          operator: NotIn
-          values:
-          - "true"
-      resourceApplyMode: Sync
-      resources:
-      - kind: Namespace
-        apiVersion: v1
-        metadata:
-          name: openshift-cloud-ingress-operator
-          labels:
-            openshift.io/cluster-monitoring: 'true'
-      - apiVersion: cloudcredential.openshift.io/v1
-        kind: CredentialsRequest
-        metadata:
+    annotations:
+      component-display-name: ${DISPLAY_NAME}
+      component-name: ${REPO_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - "true"
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - "true"
+    resourceApplyMode: Sync
+    resources:
+    - kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: openshift-cloud-ingress-operator
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
+      metadata:
+        name: cloud-ingress-operator-credentials-aws
+        namespace: openshift-cloud-ingress-operator
+      spec:
+        secretRef:
           name: cloud-ingress-operator-credentials-aws
           namespace: openshift-cloud-ingress-operator
-        spec:
-          secretRef:
-            name: cloud-ingress-operator-credentials-aws
-            namespace: openshift-cloud-ingress-operator
-          providerSpec:
-            apiVersion: cloudcredential.openshift.io/v1
-            kind: AWSProviderSpec
-            statementEntries:
-            - effect: Allow
-              resource: '*'
-              action:
-              - elasticloadbalancing:*
-              - ec2:DescribeAccountAttributes
-              - ec2:DescribeAddresses
-              - ec2:DescribeInternetGateways
-              - ec2:DescribeSecurityGroups
-              - ec2:DescribeSubnets
-              - ec2:DescribeVpcs
-              - ec2:DescribeVpcClassicLink
-              - ec2:DescribeInstances
-              - ec2:DescribeNetworkInterfaces
-              - ec2:DescribeClassicLinkInstances
-              - ec2:DescribeRouteTables
-              - ec2:AuthorizeSecurityGroupEgress
-              - ec2:AuthorizeSecurityGroupIngress
-              - ec2:CreateSecurityGroup
-              - ec2:DeleteSecurityGroup
-              - ec2:DescribeInstanceAttribute
-              - ec2:DescribeInstanceStatus
-              - ec2:DescribeNetworkAcls
-              - ec2:DescribeSecurityGroups
-              - ec2:RevokeSecurityGroupEgress
-              - ec2:RevokeSecurityGroupIngress
-              - ec2:DescribeTags
-              - ec2:CreateTags
-              - ec2:DeleteTags
-              - route53:ChangeResourceRecordSets
-              - route53:GetHostedZone
-              - route53:GetHostedZoneCount
-              - route53:ListHostedZones
-              - route53:ListHostedZonesByName
-              - route53:ListResourceRecordSets
-              - route53:UpdateHostedZoneComment
-      - apiVersion: cloudcredential.openshift.io/v1
-        kind: CredentialsRequest
-        metadata:
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: AWSProviderSpec
+          statementEntries:
+          - effect: Allow
+            resource: '*'
+            action:
+            - elasticloadbalancing:*
+            - ec2:DescribeAccountAttributes
+            - ec2:DescribeAddresses
+            - ec2:DescribeInternetGateways
+            - ec2:DescribeSecurityGroups
+            - ec2:DescribeSubnets
+            - ec2:DescribeVpcs
+            - ec2:DescribeVpcClassicLink
+            - ec2:DescribeInstances
+            - ec2:DescribeNetworkInterfaces
+            - ec2:DescribeClassicLinkInstances
+            - ec2:DescribeRouteTables
+            - ec2:AuthorizeSecurityGroupEgress
+            - ec2:AuthorizeSecurityGroupIngress
+            - ec2:CreateSecurityGroup
+            - ec2:DeleteSecurityGroup
+            - ec2:DescribeInstanceAttribute
+            - ec2:DescribeInstanceStatus
+            - ec2:DescribeNetworkAcls
+            - ec2:DescribeSecurityGroups
+            - ec2:RevokeSecurityGroupEgress
+            - ec2:RevokeSecurityGroupIngress
+            - ec2:DescribeTags
+            - ec2:CreateTags
+            - ec2:DeleteTags
+            - route53:ChangeResourceRecordSets
+            - route53:GetHostedZone
+            - route53:GetHostedZoneCount
+            - route53:ListHostedZones
+            - route53:ListHostedZonesByName
+            - route53:ListResourceRecordSets
+            - route53:UpdateHostedZoneComment
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
+      metadata:
+        name: cloud-ingress-operator-credentials-gcp
+        namespace: openshift-cloud-ingress-operator
+      spec:
+        secretRef:
           name: cloud-ingress-operator-credentials-gcp
           namespace: openshift-cloud-ingress-operator
-        spec:
-          secretRef:
-            name: cloud-ingress-operator-credentials-gcp
-            namespace: openshift-cloud-ingress-operator
-          providerSpec:
-            apiVersion: cloudcredential.openshift.io/v1
-            kind: GCPProviderSpec
-            predefinedRoles:
-            - roles/dns.admin
-            - roles/compute.networkAdmin
-            skipServiceCheck: true
-      - apiVersion: operators.coreos.com/v1alpha1
-        kind: CatalogSource
-        metadata:
-          labels:
-            opsrc-datastore: 'true'
-            opsrc-provider: redhat
-          name: ${REPO_NAME}-registry
-          namespace: openshift-${REPO_NAME}
-        spec:
-          image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - preference:
-                  matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-                weight: 1
-          tolerations:
-          - operator: Exists
-            key: node-role.kubernetes.io/infra
-            effect: NoSchedule
-          displayName: ${REPO_NAME}
-          icon:
-            base64data: ''
-            mediatype: ''
-          publisher: Red Hat
-          sourceType: grpc
-      - apiVersion: operators.coreos.com/v1
-        kind: OperatorGroup
-        metadata:
-          name: ${REPO_NAME}
-          namespace: openshift-${REPO_NAME}
-        spec:
-          targetNamespaces:
-          - openshift-${REPO_NAME}
-      - apiVersion: operators.coreos.com/v1alpha1
-        kind: Subscription
-        metadata:
-          name: ${REPO_NAME}
-          namespace: openshift-${REPO_NAME}
-        spec:
-          channel: ${CHANNEL}
-          name: ${REPO_NAME}
-          source: ${REPO_NAME}-registry
-          sourceNamespace: openshift-${REPO_NAME}
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: cloud-ingress-operator  
-          namespace: openshift-sre-sshd
-        rules:
-        - apiGroups:
-          - cloudingress.managed.openshift.io
-          resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - services/finalizers
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-kube-apiserver
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - services/finalizers
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-sre-sshd
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - services/finalizers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-ingress-operator
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-ingress-operator
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          creationTimestamp: null
-          name: cluster-config-v1-reader-cio
-          namespace: kube-system
-        rules:
-        - apiGroups:
-          - ""
-          resourceNames:
-          - cluster-config-v1
-          resources:
-          - configmaps
-          verbs:
-          - get
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-machine-api
-        rules:
-        - apiGroups:
-          - machine.openshift.io
-          resources:
-          - machines
-          - machinesets
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: prometheus-k8s
-          namespace: openshift-cloud-ingress-operator
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - endpoints
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          name: cloud-ingress-operator
-        rules:
-        - apiGroups:
-          - config.openshift.io
-          resources:
-            - infrastructures
-            - apiservers
-            - dnses
-          verbs:
-            - list
-            - get
-            - watch
-        - apiGroups:
-          - config.openshift.io
-          resources:
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: GCPProviderSpec
+          predefinedRoles:
+          - roles/dns.admin
+          - roles/compute.networkAdmin
+          skipServiceCheck: true
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        labels:
+          opsrc-datastore: 'true'
+          opsrc-provider: redhat
+        name: ${REPO_NAME}-registry
+        namespace: openshift-${REPO_NAME}
+      spec:
+        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                - key: node-role.kubernetes.io/infra
+                  operator: Exists
+              weight: 1
+        tolerations:
+        - operator: Exists
+          key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+        displayName: ${REPO_NAME}
+        icon:
+          base64data: ''
+          mediatype: ''
+        publisher: Red Hat
+        sourceType: grpc
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: ${REPO_NAME}
+        namespace: openshift-${REPO_NAME}
+      spec:
+        targetNamespaces:
+        - openshift-${REPO_NAME}
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: ${REPO_NAME}
+        namespace: openshift-${REPO_NAME}
+      spec:
+        channel: ${CHANNEL}
+        name: ${REPO_NAME}
+        source: ${REPO_NAME}-registry
+        sourceNamespace: openshift-${REPO_NAME}
+      # cloud-ingress-operator clusterrole and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+          - infrastructures
           - apiservers
-          verbs:
-          - patch
-          - update
+          - dnses
+        verbs:
+          - list
+          - get
           - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: cloud-ingress-operator
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: cloud-ingress-operator
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: prometheus-k8s
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: prometheus-k8s
-        subjects:
-        - kind: ServiceAccount
-          name: prometheus-k8s
-          namespace: openshift-monitoring
-      - apiVersion: rbac.authorization.k8s.io/v1
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - apiservers
+        verbs:
+        - patch
+        - update
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cloud-ingress-operator
+    # Openshift-monitoring role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch        
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
         kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        rules:
-        - apiGroups:
-          - cloudingress.managed.openshift.io
-          resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - services/finalizers
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resourceNames:
-          - cloud-ingress-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - replicasets
-          verbs:
-          - get
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator-cluster-config-v1-reader
-          namespace: kube-system
-          labels:
-            owner: cloud-ingress-operator
-            owner.namespace: openshift-cloud-ingress-operator
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: Role
-          name: cluster-config-v1-reader-cio
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-sre-sshd
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-sre-sshd
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-sre-sshd
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-sre-sshd
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-ingress
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-ingress
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-machine-api
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-machine-api
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-kube-apiserver
-        subjects:
-        - kind: ServiceAccount
-          name: cloud-ingress-operator
-          namespace: openshift-cloud-ingress-operator
-        roleRef:
-          kind: Role
-          name: cloud-ingress-operator
-          namespace: openshift-kube-apiserver
-          apiGroup: rbac.authorization.k8s.io
-      - apiVersion: rbac.authorization.k8s.io/v1
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    # Openshift-cloud-ingress-operator role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        - services
+        - services/finalizers
+        - endpoints
+        - persistentvolumeclaims
+        - events
+        - configmaps
+        - secrets
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        - replicasets
+        - statefulsets
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - apps
+        resourceNames:
+        - cloud-ingress-operator
+        resources:
+        - deployments/finalizers
+        verbs:
+        - update
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        verbs:
+        - get
+      - apiGroups:
+        - apps
+        resources:
+        - replicasets
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
         kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-ingress-operator
-        rules:
-        - apiGroups:
-          - operator.openshift.io
-          resources:
-          - ingresscontrollers
-          verbs:
-          - get
-          - list
-          - watch
-          - patch
-          - delete
-          - create
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+        apiGroup: rbac.authorization.k8s.io
+    # Kube-system role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cluster-config-v1-reader-cio
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - cluster-config-v1
+        resources:
+        - configmaps
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator-cluster-config-v1-reader
+        namespace: kube-system
+        labels:
+          owner: cloud-ingress-operator
+          owner.namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
         kind: Role
-        metadata:
-          name: cloud-ingress-operator
-          namespace: openshift-ingress
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          - services/finalizers
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-
+        name: cluster-config-v1-reader-cio
+    # Openshift-sre-sshd role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-sre-sshd
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - services/finalizers
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-sre-sshd
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        kind: Role
+        name: cloud-ingress-operator
+        namespace: openshift-sre-sshd
+        apiGroup: rbac.authorization.k8s.io
+    # Openshift-machine-api role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        - machinesets
+        verbs:
+        - get
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-machine-api
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        kind: Role
+        name: cloud-ingress-operator
+        namespace: openshift-machine-api
+        apiGroup: rbac.authorization.k8s.io
+      # Openshift-kube-apiserver role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-kube-apiserver
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - services/finalizers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch        
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-kube-apiserver
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        kind: Role
+        name: cloud-ingress-operator
+        namespace: openshift-kube-apiserver
+        apiGroup: rbac.authorization.k8s.io
+    # Openshift-ingress role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-ingress
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        - services/finalizers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-ingress
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        kind: Role
+        name: cloud-ingress-operator
+        namespace: openshift-ingress
+        apiGroup: rbac.authorization.k8s.io
+    # Openshift-ingress-operator role and binding
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-ingress-operator
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - ingresscontrollers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - delete
+        - create
+        - update
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-ingress-operator
+        namespace: openshift-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: cloud-ingress-operator
+        namespace: openshift-cloud-ingress-operator
+      roleRef:
+        kind: Role
+        name: cloud-ingress-operator
+        namespace: openshift-ingress-operator
+        apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Tabbing got messed up (doesn't seem to affect deployment though)

Stage deployments were failing due to an incorrect role definition. Somehow I added two different definitions of the same role. This PR removes the incorrect definition of that role.