### PR TITLE
Remove sshd rbac and openshift-sre-sshd namespace from deployment

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             # "" so that the cache can read objects outside its namespace
             - name: WATCH_NAMESPACE
-              value: "openshift-sre-sshd,openshift-cloud-ingress-operator,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver,openshift-machine-api"
+              value: "openshift-cloud-ingress-operator,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver,openshift-machine-api"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -356,48 +356,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: cluster-config-v1-reader-cio
-    # Openshift-sre-sshd role and binding
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        name: cloud-ingress-operator
-        namespace: openshift-sre-sshd
-      rules:
-      - apiGroups:
-        - ""
-        resources:
-        - services
-        - services/finalizers
-        verbs:
-        - create
-        - delete
-        - get
-        - list
-        - patch
-        - update
-        - watch
-      - apiGroups:
-        - apps
-        resources:
-        - deployments
-        verbs:
-        - get
-        - list
-        - watch
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: cloud-ingress-operator
-        namespace: openshift-sre-sshd
-      subjects:
-      - kind: ServiceAccount
-        name: cloud-ingress-operator
-        namespace: openshift-cloud-ingress-operator
-      roleRef:
-        kind: Role
-        name: cloud-ingress-operator
-        namespace: openshift-sre-sshd
-        apiGroup: rbac.authorization.k8s.io
     # Openshift-machine-api role and binding
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role


### PR DESCRIPTION
https://github.com/openshift/managed-cluster-config/pull/977

Removes the `openshift-sre-sshd` namespace and related rbac from default deployment. These should only be deployed on hives. 