### PR TITLE
chore: shorten the creation of infra

### DIFF
--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
 	corev1 "k8s.io/api/core/v1"
@@ -16,19 +15,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	infra := &configv1.Infrastructure{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "cluster",
-			Namespace: "",
-		},
-		Status: configv1.InfrastructureStatus{
-			PlatformStatus: &configv1.PlatformStatus{
-				AWS: &configv1.AWSPlatformStatus{
-					Region: "eu-west-1",
-				},
-			},
-		},
-	}
+	infra := testutils.CreateInfraObject("test-cluster", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
 
 	fakeSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -111,20 +98,7 @@ func (m *mockELBClient) DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsO
 }
 
 func TestHealthcheck(t *testing.T) {
-	infra := &configv1.Infrastructure{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "cluster",
-			Namespace: "",
-		},
-		Status: configv1.InfrastructureStatus{
-			InfrastructureName: "dummy-cluster",
-			PlatformStatus: &configv1.PlatformStatus{
-				AWS: &configv1.AWSPlatformStatus{
-					Region: "us-east-1",
-				},
-			},
-		},
-	}
+	infra := testutils.CreateInfraObject("dummy-cluster", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
 
 	objs := []runtime.Object{infra}
 	mocks := testutils.NewTestMock(t, objs)

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"testing"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
 	computev1 "google.golang.org/api/compute/v1"
@@ -23,20 +22,7 @@ func TestNewClient(t *testing.T) {
 		"token_uri": "http://localhost:8080/token"
 	  }`
 
-	infra := &configv1.Infrastructure{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "cluster",
-			Namespace: "",
-		},
-		Status: configv1.InfrastructureStatus{
-			APIServerURL: "https://api.dummy.fsrl.s1.testing.org:6443",
-			PlatformStatus: &configv1.PlatformStatus{
-				GCP: &configv1.GCPPlatformStatus{
-					Region: "eu-west-1",
-				},
-			},
-		},
-	}
+	infra := testutils.CreateGCPInfraObject("sut", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
 
 	fakeSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
As we have already a function to create an infra, we don't need to build the struct individually in functions
This only contains testing file changes, `make test` passes