### PR TITLE
Missed some roles needing a bit more rbac

### DIFF
--- a/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
@@ -21,3 +21,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+

--- a/deploy/20_cloud-ingress-operator_machine.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_machine.Role.yaml
@@ -27,3 +27,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+

--- a/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress-operator.Role.yaml
@@ -32,3 +32,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+

--- a/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
@@ -21,3 +21,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -432,6 +432,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -469,7 +481,19 @@ objects:
         verbs:
         - get
         - list
-        - watch        
+        - watch
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -508,6 +532,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch        
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -557,6 +593,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch        
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
These roles still need rbac for the cloudingressoperator CRDs so the operator can properly watch those namespaces. 