### PR TITLE
remove openshift-sre-sshd namespace deployment from CIO 

### DIFF
--- a/deploy/20_cloud-ingress-operator._openshift-sre-ssh.Namespace.yaml
+++ b/deploy/20_cloud-ingress-operator._openshift-sre-ssh.Namespace.yaml
@@ -1,3 +1,0 @@
-kind: Namespace
-metadata:
-  name: openshift-sre-sshd


### PR DESCRIPTION
Removing deployment of the openshift-sre-sshd namepace from OLM, as its causing issues during build

```
17:49:05   File "./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py", line 130, in <module>
17:49:05     raise UnsupportedRegistryResourceKind(doc['kind'], path)
17:49:05 __main__.UnsupportedRegistryResourceKind: The resource at deploy/20_cloud-ingress-operator._openshift-sre-ssh.Namespace.yaml of kind Namespace is not supported
```