### PR TITLE
Add lingering missing permissions and temporary cluster perms for upgrade fix

### DIFF
--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -21,3 +21,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  - secrets
+  verbs:
+  - "*"

--- a/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_kube-apiserver.Role.yaml
@@ -13,6 +13,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:

--- a/deploy/20_cloud-ingress-operator_machine.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_machine.Role.yaml
@@ -11,6 +11,8 @@ rules:
   - machinesets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_openshift-ingress.Role.yaml
@@ -13,6 +13,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
 - apiGroups:
   - apps
   resources:

--- a/deploy/20_cloud-ingress-operator_sshd.Role.yaml
+++ b/deploy/20_cloud-ingress-operator_sshd.Role.yaml
@@ -33,3 +33,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -185,6 +185,14 @@ objects:
         - patch
         - update
         - watch
+      - apiGroups:
+        - ""
+        resources:
+          - pods
+          - configmaps
+          - secrets
+        verbs:
+          - "*"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -388,6 +396,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - cloudingress.managed.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -416,6 +436,8 @@ objects:
         - machinesets
         verbs:
         - get
+        - list
+        - watch
       - apiGroups:
         - ""
         resources:
@@ -474,6 +496,8 @@ objects:
         - get
         - list
         - watch
+        - create
+        - update
       - apiGroups:
         - apps
         resources:
@@ -524,6 +548,8 @@ objects:
         - get
         - list
         - watch
+        - create
+        - update
       - apiGroups:
         - apps
         resources:


### PR DESCRIPTION
This ensures the operator can watch its own CRDs in the openshift-sre-sshd namespace, plus some other small permissions around services and machines in the openshift-ingress, openshift-kube-apiserver and openshift-machine-api namespaces. 

This also adds some permissions back to the clusterrole temporarily to work around issues upgrading the operator via OLM