### PR TITLE
Add patch and update to machine object during public private swtich

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -271,6 +271,8 @@ objects:
         - get
         - list
         - watch
+        - patch
+        - update
       - apiGroups:
         - ""
         resources:

--- a/resources/20_cloud-ingress-operator_machine.Role.yaml
+++ b/resources/20_cloud-ingress-operator_machine.Role.yaml
@@ -13,6 +13,8 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
When switching from private to public, the machine objects gets patched to match the list of NLBs they're registered with. Currently this permission is missing, so while the LBs and DNS gets updated correctly, the Machine CRs are not representative of the actual config.

