### PR TITLE
role fix to allow service deletion in openshift-kube-apiserver namespace

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -332,6 +332,7 @@ objects:
         - watch
         - create
         - update
+        - delete
       - apiGroups:
         - apps
         resources:

--- a/pkg/controller/apischeme/apischeme_controller.go
+++ b/pkg/controller/apischeme/apischeme_controller.go
@@ -277,7 +277,7 @@ func (r *ReconcileAPIScheme) Reconcile(ctx context.Context, request reconcile.Re
 			reqLogger.Info(fmt.Sprintf("LoadBalancer was deleted, deleting service %s/service/%s to recover", found.GetNamespace(), found.GetName()))
 			err := r.client.Delete(context.TODO(), found)
 			if err != nil {
-				reqLogger.Info(fmt.Sprintf("Failed to delete the %s/service/%s LoadBalancer, it is already deleted", found.GetNamespace(), found.GetName()))
+				reqLogger.Error(err, fmt.Sprintf("Failed to delete the %s/service/%s LoadBalancer, it could already be deleted", found.GetNamespace(), found.GetName()))
 			}
 		}
 

--- a/resources/20_cloud-ingress-operator_kube-apiserver.Role.yaml
+++ b/resources/20_cloud-ingress-operator_kube-apiserver.Role.yaml
@@ -15,6 +15,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
Allows  cio's to delete rh-api service in openshift-kube-apiserver for recovery when the associated LB was manually deleted