### PR TITLE
OSD-9902  Remove label check in healthchecks

### DIFF
--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -75,13 +75,9 @@ func (c *Client) SetDefaultAPIPublic(ctx context.Context, kclient client.Client,
 
 // Healthcheck performs basic calls to make sure client is healthy
 func (c *Client) Healthcheck(ctx context.Context, kclient client.Client) error {
-	elbList := make([]*elb.LoadBalancerDescription, 0)
 	input := &elb.DescribeLoadBalancersInput{}
-	err := c.elbClient.DescribeLoadBalancersPages(input, func(page *elb.DescribeLoadBalancersOutput, lastPage bool) bool {
-		elbList = append(elbList, page.LoadBalancerDescriptions...)
-		return lastPage
-	})
-	
+	_, err := c.elbClient.DescribeLoadBalancers(input)
+
 	return err
 }
 

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -57,24 +57,9 @@ type mockELBClient struct {
 	elbiface.ELBAPI
 }
 
-func (m *mockELBClient) DescribeLoadBalancersPages(params *elb.DescribeLoadBalancersInput, fn func(*elb.DescribeLoadBalancersOutput, bool) bool) error {
+func (m *mockELBClient) DescribeLoadBalancers(params *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
 	// mock response/functionality
-
-	// simulate multiple pages
 	out := &elb.DescribeLoadBalancersOutput{
-		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
-			{
-				LoadBalancerName: aws.String("lb-1"),
-			},
-			{
-				LoadBalancerName: aws.String("lb-2"),
-			},
-		},
-		NextMarker: aws.String("marker"),
-	}
-	fn(out, false)
-
-	out = &elb.DescribeLoadBalancersOutput{
 		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 			{
 				LoadBalancerName: aws.String("lb-3"),
@@ -82,9 +67,8 @@ func (m *mockELBClient) DescribeLoadBalancersPages(params *elb.DescribeLoadBalan
 		},
 		NextMarker: aws.String(""),
 	}
-	fn(out, true)
 
-	return nil
+	return out, nil
 }
 
 func (m *mockELBClient) DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -71,24 +71,8 @@ func (c *Client) SetDefaultAPIPublic(ctx context.Context, kclient client.Client,
 
 // Healthcheck performs basic calls to make sure client is healthy
 func (c *Client) Healthcheck(ctx context.Context, kclient client.Client) error {
-	out, err := c.computeService.RegionBackendServices.List(c.projectID, c.region).Do()
-	if err != nil {
-		return err // possible client deformation
-	}
-
-	return performHealthCheck(out, c.clusterName)
-}
-
-func performHealthCheck(l *computev1.BackendServiceList, clusterName string) error {
-	// checking internal lb to ensure it's there and available to use by cloud-client
-	intLBName := clusterName + "-api-internal"
-	for _, lb := range l.Items {
-		if lb.Name == intLBName {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("internal lb not found: exiting to refresh")
+	_, err := c.computeService.RegionBackendServices.List(c.projectID, c.region).Do()
+	return err 
 }
 
 func newClient(ctx context.Context, serviceAccountJSON []byte) (*Client, error) {

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -6,7 +6,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
-	computev1 "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,21 +56,5 @@ func TestNewClient(t *testing.T) {
 
 	if cli == nil {
 		t.Error("cli should have been initialized")
-	}
-}
-
-// testing only performHealthCheck
-// mocking c.computeService.RegionBackendServices.List(c.projectID, c.region).Do() is hard coz they're not bound to an interface
-func TestPerformHealthCheck(t *testing.T) {
-	l := &computev1.BackendServiceList{
-		Items: []*computev1.BackendService{
-			{
-				Name: "test-api-internal",
-			},
-		}}
-
-	err := performHealthCheck(l, "test")
-	if err != nil {
-		t.Error("tests shouldn't have failed:", err)
 	}
 }


### PR DESCRIPTION
Checks on labels in the HealthChecks were leading to the operator restart in case the underlyin LB has been deleted. 
Now the recreate of the LB is managed in the code, there is no reason for restarting (has 'deleted LB' is a standard state which is managed by the operator). 