### PR TITLE
osd-10155 fix 'nil pointer dereference' error for case of nil return value

### DIFF
--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -208,13 +208,12 @@ func (c *Client) findGCPForwardingRuleForExtIP(rhapiLbIP string) (*compute.Forwa
 	if err != nil {
 		return nil, err
 	}
-	var fr *compute.ForwardingRule
 	for _, lb := range response.Items {
 		if lb.IPAddress == rhapiLbIP {
-			fr = lb
+			return lb, nil
 		}
 	}
-	return fr, nil
+	return nil, nil
 }
 
 func (c *Client) removeDNSForService(kclient client.Client, svc *corev1.Service, dnsName string) error {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -22,9 +22,10 @@ type ForwardingRuleNotFoundError struct {
 
 func (e *ForwardingRuleNotFoundError) Error() string { return e.e }
 
+// Only needed for GCP
 func ForwardingRuleNotFound(reason string) error {
 	return &ForwardingRuleNotFoundError{
-		e: "forwarding rule for svc not found in cloud provider. " + reason,
+		e: "forwarding rule for svc not found in GCP. " + reason,
 	}
 }
 


### PR DESCRIPTION
[osd-10155](https://issues.redhat.com/browse/osd-10155) fix 'nil pointer dereference' error for case of nil return value #246
 
 Fix for the following error on CIO pod:
 
 ```E0316 20:40:14.687441       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1239 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x20d67c0, 0x3746810)
	pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	pkg/mod/k8s.io/apimachinery@v0.19.2/pkg/util/runtime/runtime.go:48 +0x86
panic(0x20d67c0, 0x3746810)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/openshift/cloud-ingress-operator/pkg/cloudclient/gcp.(*Client).ensureDNSForService(0xc000db1ec0, 0x284d4e0, 0xc000cc3590, 0xc000553b00, 0xc000c977e0, 0x6, 0xc00035bc20, 0x0)
	/workdir/pkg/cloudclient/gcp/private.go:133 +0x89
github.com/openshift/cloud-ingress-operator/pkg/cloudclient/gcp.(*Client).ensureAdminAPIDNS(...)
	/workdir/pkg/cloudclient/gcp/private.go:34
github.com/openshift/cloud-ingress-operator/pkg/cloudclient/gcp.(*Client).EnsureAdminAPIDNS(0xc000db1ec0, 0x2831368, 0xc000040038, 0x284d4e0, 0xc000cc3590, 0xc000f54180, 0xc000553b00, 0x285df98, 0xc000553b00)
	/workdir/pkg/cloudclient/gcp/gcp.go:44 +0x69
github.com/openshift/cloud-ingress-operator/pkg/controller/apischeme.(*ReconcileAPIScheme).Reconcile(0xc00000d3b0, 0x28313d8, 0xc000f6e5d0, 0xc0002c0d40, 0x20, 0xc000c97744, 0x6, 0xc000f6e5d0, 0xc000030000, 0x2218160, ...)
	/workdir/pkg/controller/apischeme/apischeme_controller.go:256 +0x9f8```