### PR TITLE
OSD-11442 - Address gosec lint warnings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,10 +47,10 @@ const (
 	MaxAPIRetries int = 10
 
 	// AWSSecretName
-	AWSSecretName string = "cloud-ingress-operator-credentials-aws"
+	AWSSecretName string = "cloud-ingress-operator-credentials-aws" //#nosec G101 -- This is a false positive
 
 	// GCPSecretName
-	GCPSecretName string = "cloud-ingress-operator-credentials-gcp"
+	GCPSecretName string = "cloud-ingress-operator-credentials-gcp" //#nosec G101 -- This is a false positive
 
 	// OperatorNamespace
 	OperatorNamespace string = "openshift-cloud-ingress-operator"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e // indirect
 	google.golang.org/api v0.35.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -1197,6 +1197,8 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -127,6 +127,7 @@ func TestRemoveAWSELB(t *testing.T) {
 				Name:      machine.GetName(),
 				Namespace: machine.GetNamespace(),
 			}
+			machine := machine
 			// reload the object to make sure we're not just working with the "in-memory"
 			// representation, that being, the un-saved one.
 			err := mocks.FakeKubeClient.Get(context.TODO(), machineInfo, &machine)
@@ -170,6 +171,7 @@ func TestRemoveAWSELB(t *testing.T) {
 				Name:      machine.GetName(),
 				Namespace: machine.GetNamespace(),
 			}
+			machine := machine
 
 			err = mocks.FakeKubeClient.Get(context.TODO(), machineInfo, &machine)
 			if err != nil {
@@ -200,7 +202,6 @@ func TestAWSProviderDecode(t *testing.T) {
 		Name:      machine.GetName(),
 		Namespace: machine.GetNamespace(),
 	}
-
 	err := mocks.FakeKubeClient.Get(context.TODO(), machineInfo, &machine)
 	if err != nil {
 		t.Fatalf("Couldn't reload machine %s: %v", machine.GetName(), err)


### PR DESCRIPTION
Reassigned the value of the machine in the for loop to avoid "G601: Implicit memory aliasing in for loop" error,  add a false positive to the AWSSecretName and GCPSecretName to avoid "G101: Potential hardcoded credentials" error and added package "golang.org/x/sys/unix".