### PR TITLE
Set ELBConnectionTimeout on IngressController for v4.11+

### DIFF
--- a/pkg/controller/publishingstrategy/publishingstrategy_controller.go
+++ b/pkg/controller/publishingstrategy/publishingstrategy_controller.go
@@ -515,6 +515,12 @@ func validatePatchableSpec(ingressController ingresscontroller.IngressController
 			return false, IngressControllerEndPoint
 		}
 	}
+	if baseutils.IsVersionHigherThan("4.11") {
+		if !(reflect.DeepEqual(desiredSpec.EndpointPublishingStrategy.LoadBalancer.ProviderParameters,
+			ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.ProviderParameters)) {
+			return false, IngressControllerEndPoint
+		}
+	}
 
 	return true, ""
 }

--- a/pkg/controller/routerservice/router_service_controller.go
+++ b/pkg/controller/routerservice/router_service_controller.go
@@ -3,6 +3,7 @@ package routerservice
 import (
 	"context"
 
+	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,7 +101,8 @@ func (r *ReconcileRouterService) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Only check LoadBalancer service types for annotations
-	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+	// Only set timeout annotations on services for < OCP 4.11. In 4.11+, the cluster-ingress-operator maintains this annotation
+	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer && !baseutils.IsVersionHigherThan("4.11") {
 		if !metav1.HasAnnotation(svc.ObjectMeta, ELBAnnotationKey) ||
 			svc.ObjectMeta.Annotations[ELBAnnotationKey] != ELBAnnotationValue {
 			reqLogger.Info("Updating annotation for " + svc.Name)

--- a/pkg/ingresscontroller/ingresscontroller.go
+++ b/pkg/ingresscontroller/ingresscontroller.go
@@ -88,6 +88,7 @@ const (
 )
 
 type AWSClassicLoadBalancerParameters struct {
+	ConnectionIdleTimeout metav1.Duration `json:"connectionIdleTimeout,omitempty"`
 }
 
 type AWSNetworkLoadBalancerParameters struct {


### PR DESCRIPTION
As of OCP v4.11, cluster-ingress-operator allows management of AWS ELB idle connection timeouts by setting them in the spec of the IngressController: https://github.com/openshift/cluster-ingress-operator/pull/451 . Since cloud-ingress-operator currently sets that idle timeout by annotating the LoadBalancer service object directly, it was causing a fight between the two operators were cloud-ingress-operator was applying the annotation to the service and cluster-ingress-operator was removing it, causing frequent AWS calls as the setting was modified back and forth.

This PR updates the publishingstrategy controller to set the ELB idle timeout directly in the IngressController for v4.11+ clusters, and to patch any IngressControllers owned by cloud-ingress-operator that lack that field in their spec. 

I tested this against 4.10 and 4.11 clusters. On 4.10, the current behavior still worked correctly and the cloud-ingress-operator makes no attempt to set the connectionIdleTimeout on the IngressController. On 4.11, it correctly patched the default IngressController to set the idle connection timeout there, and once set it no longer competes with the cluster-ingress-operator to set the annotation on the LB service object.