### PR TITLE
Include tags with ELBv2 create API call

### DIFF
--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -858,7 +858,15 @@ func TestCreateNetworkLoadBalancer(t *testing.T) {
 		client := &Client{
 			elbv2Client: mockCreateLoadBalancer{Resp: test.Resp, ErrResp: test.ErrResp},
 		}
-		resp, err := client.createNetworkLoadBalancer(test.LbName, test.Scheme, test.Subnet)
+
+		tag := elbv2.Tag{
+			Key:   aws.String("red-hat-managed"),
+			Value: aws.String("true"),
+		}
+
+		tags := []*elbv2.Tag{&tag}
+
+		resp, err := client.createNetworkLoadBalancer(test.LbName, test.Scheme, test.Subnet, tags)
 		if err == nil && test.ErrorExpected || err != nil && !test.ErrorExpected {
 			t.Fatalf("Test return mismatch. Expect error? %t: Return %+v", test.ErrorExpected, err)
 		}


### PR DESCRIPTION
This PR moves tag creation for the NLB to the create API call. This is done to support STS tag condition keys where we limit permissions available to OpenShift to only manage AWS resources that contain tags such as `red-hat-managed=true` 

AWS does not support adding these tags to `Delete` or `Describe` API for the `elasticloadbalancer`, `route53` or `ec2` service prefixs see [this](https://docs.aws.amazon.com/service-authorization/latest/reference/list_elasticloadbalancingv2.html)  document for more information.

The new policy for STS clusters with condition keys set would look like the following.

```
@@ -4,9 +4,6 @@
       {
           "Effect": "Allow",
           "Action": [
-              "elasticloadbalancing:AddTags",
-              "elasticloadbalancing:CreateListener",
-              "elasticloadbalancing:CreateLoadBalancer",
               "elasticloadbalancing:DeleteLoadBalancer",
               "elasticloadbalancing:DescribeLoadBalancers",
               "elasticloadbalancing:DescribeTags",
@@ -20,6 +17,22 @@
               "route53:ListResourceRecordSets"
           ],
           "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "elasticloadbalancing:AddTags",
+            "elasticloadbalancing:CreateListener",
+            "elasticloadbalancing:CreateLoadBalancer"
+        ],
+        "Resource": [
+            "*"
+        ],
+        "Condition": {
+            "StringEquals": {
+                "aws:RequestTag/red-hat-managed": "true"
+            }
+        }
       }
   ]
 }

```