### PR TITLE
Set cluster version environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup Global Variables
+	cli := mgr.GetClient()
+	if err := baseutils.SetClusterVersion(cli); err != nil {
+		setupLog.Error(err, "")
+		os.Exit(1)
+	}
+
 	// setup apischemecontroller with mgr
 	if err = (&apischemecontroller.APISchemeReconciler{
 		Client: mgr.GetClient(),


### PR DESCRIPTION
## What

Restores a missing logic block that sets the `CLUSTER_VERSION` environment variable in `main.go`.

## Why

This code was missing in the Operator SDK migration #267 and as a result is causing CIO to perform heavy API load on cloud providers by constantly annotation the `router-default` service.
