### PR TITLE
Migrate machine v1beta1 to openshift/api and rework machine provider spec encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,28 +20,29 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/operator-framework/operator-lib/leader"
-	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"os"
-	awsproviderapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	amapiv1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/cloudclient"
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	"github.com/openshift/cloud-ingress-operator/pkg/localmetrics"
 	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
-	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	osdmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
+	"github.com/operator-framework/operator-lib/leader"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	awsproviderapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	aapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -66,10 +67,13 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(configv1.Install(scheme))
-	utilruntime.Must(machineapi.AddToScheme(scheme))
+	utilruntime.Must(amapiv1.Install(scheme))
 	utilruntime.Must(ingresscontroller.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
-	utilruntime.Must(awsproviderapi.SchemeBuilder.AddToScheme(scheme))
+	utilruntime.Must(aapi.AddToScheme(scheme))
+	scheme.AddKnownTypes(awsproviderapi.SchemeGroupVersion,
+		&awsproviderapi.AWSMachineProviderConfig{},
+	)
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -10,10 +10,10 @@ import (
 	"google.golang.org/api/option"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machineapi "github.com/openshift/api/machine/v1beta1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
-	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/utils/machines.go
+++ b/pkg/utils/machines.go
@@ -5,7 +5,7 @@ package utils
 import (
 	"context"
 
-	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machineapi "github.com/openshift/api/machine/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 


### PR DESCRIPTION
# What it does
- Migrates all usage of the machine api v1beta1 to its present location in [openshift/api](https://github.com/openshift/api/tree/master/machine/v1beta1) rather than the old (and outdated) location in [openshift/machine-api-operator](https://github.com/openshift/machine-api-operator/tree/release-4.9/pkg/apis/machine/v1beta1)
- Rewrites the Machine Provider Spec encoding and decoding functions to handle both the old/new Group/Version/Kinds found in OCP <4.11 and 4.11+
- Adds tests for the above.
 
# Why
OCP 4.11+ uses a different GVK of `machine.openshift.io/v1beta1` for objects store in the [Machine Provider Spec](https://github.com/openshift/api/blob/4226c2167e40c62b09e2db083d1c0051fafba7da/machine/v1beta1/0000_10_machine.crd.yaml#L181) (for both GCP and AWS). Prior to 4.11, `awsproviderconfig.openshift.io/v1beta1` and `gcpprovider.openshift.io/v1beta1` were the GVKs used.

Through troubleshooting [OHSS-15958](https://issues.redhat.com//browse/OHSS-15958) we learned that CIO is having issues decoding the MachineProviderSpec, as it does not have the `machine.openshift.io/v1beta1` API scheme registered. This is, in actual fact, not the case - CIO is registering that API scheme, however, the old MachineProviderSpec decoder that CIO was using registers only the `awsproviderconfig.openshift.io/v1beta` scheme, thus triggering the error when a `machine.openshift.io/v1beta1` GVK is found. [0]  The result of this is that on 4.11+ clusters CIO throws an error when parsing the MachineProviderSpec of control plane machines, and does not complete its operations successfully.

The only way I can think to resolve this is to ensure that CIO:
- is migrated entirely away from any use of the old API location in `machine-api-operator` 
- has MachineProviderSpec decoding and encoding functions that will work with both types of GVK

This PR does that, and adds tests to ensure that decoding and encoding of both variants of MachineProviderSpec (for GCP and AWS) are able to be handled.

Referencs:

- [OSD-13608](https://issues.redhat.com//browse/OSD-13608)
- [OHSS-15958](https://issues.redhat.com//browse/OHSS-15958)


[0] https://github.com/openshift/cluster-api-provider-aws/blob/acf4a8e03420aa0981b3bd2d702d039e0d499e62/pkg/apis/awsproviderconfig/v1alpha1/register.go#L60
