### PR TITLE
Fixing debug example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can quickly debug the operator on your existing OSD cluster by following the
         "type": "go",
         "request": "launch",
         "name": "Launch Program",
-        "program": "${workspaceFolder}/cmd/manager/main.go",
+        "program": "${workspaceFolder}/main.go",
         "env":{
             "WATCH_NAMESPACE": "openshift-cloud-ingress-operator,openshift-ingress,openshift-ingress-operator,openshift-kube-apiserver,openshift-machine-api"
         }


### PR DESCRIPTION
This PR corrects a mistake in the `README` that was pointing to the old location of `main.go` prior to the OperatorSDK v1 migration.