### PR TITLE
Remove deprecated ioutil usage

### DIFF
--- a/pkg/cloudclient/aws/shared_credentials_file.go
+++ b/pkg/cloudclient/aws/shared_credentials_file.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -12,13 +12,16 @@ import (
 // SharedCredentialsFileFromSecret returns a path to the shared creds file created using provided secret
 // configure the aws session using file to use credentials eg
 // sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
-// if err != nil {
-// 	// handle error
-// }
-// options := session.Options{
-// 	SharedConfigState: session.SharedConfigEnable,
-// 	SharedConfigFiles: []string{sharedCredentialsFile},
-// }
+//
+//	if err != nil {
+//		// handle error
+//	}
+//
+//	options := session.Options{
+//		SharedConfigState: session.SharedConfigEnable,
+//		SharedConfigFiles: []string{sharedCredentialsFile},
+//	}
+//
 // sess := session.Must(session.NewSessionWithOptions(options))
 func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
 	var data []byte
@@ -36,7 +39,7 @@ func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
 
 	}
 
-	f, err := ioutil.TempFile("", "aws-shared-credentials")
+	f, err := os.CreateTemp("", "aws-shared-credentials")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create file for shared credentials")
 	}

--- a/pkg/cloudclient/aws/shared_credentials_file_test.go
+++ b/pkg/cloudclient/aws/shared_credentials_file_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -96,7 +95,7 @@ aws_secret_access_key = asdf1234
 
 			if test.err == "" {
 				assert.NoError(t, err)
-				data, err := ioutil.ReadFile(credPath)
+				data, err := os.ReadFile(credPath)
 				t.Log(data)
 				assert.NoError(t, err)
 				assert.Equal(t, string(data), test.sharedConfig)


### PR DESCRIPTION
```
SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.
```

This removes use of this deprecated stdlib module.