### PR TITLE
Use RFC3339 timestamps for improved human readability 

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -1,3 +1,4 @@
+//go:build fips_enabled
 // +build fips_enabled
 
 // BOILERPLATE GENERATED -- DO NOT EDIT

--- a/go.mod
+++ b/go.mod
@@ -4,26 +4,29 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.44.86
+	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible
 	github.com/openshift/cluster-api-provider-gcp v0.0.0
-	github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07
 	github.com/openshift/operator-custom-metrics v0.5.0
 	github.com/operator-framework/operator-lib v0.11.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.55.0
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.19.1
 	google.golang.org/api v0.88.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/cluster-api-provider-aws v0.0.0
 	sigs.k8s.io/controller-runtime v0.12.3
 )
-
-require k8s.io/klog v1.0.0 // indirect
 
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect
@@ -42,7 +45,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -66,7 +68,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -76,7 +78,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
@@ -91,13 +92,11 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	osdmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 	"github.com/operator-framework/operator-lib/leader"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	awsproviderapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
 
@@ -87,7 +88,10 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+		// Remove misleading controller-runtime stack traces https://github.com/kubernetes-sigs/kubebuilder/issues/1593
+		StacktraceLevel: zapcore.DPanicLevel,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
[OSD-15112](https://issues.redhat.com//browse/OSD-15112)

* Defaulting timestamps to RFC3339 instead of epoch time and removing misleading stack traces that can show up to match https://github.com/openshift/aws-vpce-operator/blob/main/main.go#LL78-L83C3
* go.mod wasn't formatted for whatever reason
* Ran `make ensure-fips` which might have gotten missed in a previous `make boilerplate-update`

The logs now look like this:
```json
{"level":"error","ts":"2023-02-06T21:44:55-05:00","logger":"setup","msg":"unable to get WatchNamespace,the manager will watch and manage resources in all namespaces","error":"WATCH_NAMESPACE must be set"}
{"level":"info","ts":"2023-02-06T21:44:55-05:00","logger":"leader","msg":"Trying to become the leader."}
{"level":"error","ts":"2023-02-06T21:44:55-05:00","logger":"setup","msg":"failed to setup leader lock","error":"namespace not found for current environment"}
```