### PR TITLE
Remove default IC ownership based on 'new' managed ingress feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ The operator does not manage any kind of VPC peering or VPN connectivity into th
 
 As mentioned above, the operator is controlled through custom Kubernetes resources, `APIScheme` and `PublishingStrategy`. They are documented below:
 
+### `PublishingStrategy.applicationIngress` Deprecation 
+Managing cluster ingress controllers (`applicationIngress`) through the Cloud Ingress Operator is being deprecated in epic [SDE-1768](https://issues.redhat.com/browse/SDE-1768). 
+
+If the feature label is present (`legacy-ingress-support: false`) on the `PublishingStrategy` resource, `applicationIngress` resources are either not reconciled at all, or only reconcile the default ingress controller, depending on the OCP version of the cluster.
+
+If the cluster's OCP version is `4.13.0` or greater and the feature label is present, we do not reconcile any `IngressController` resources through this operator. Upgrading from `4.12->4.13` with this feature label enabled will remove the `Owner: cloud-ingress-operator` annotation from the default ingress controller.  
+
+If the cluster's OCP version is less than `4.13.0` or greater and the feature label is present, the **default** ingress controller will still exist in `PublishingStrategy.applicationIngress`, but no additional `apps2` ingress controller will be allowed to be created in `applicationIngress`, or reconciled by the Cloud Ingress Operator. 
+
+The only exception to this is if the customer has an existing `apps2` installation. They will be able to update and delete this as normal until they migrate to using natively managed second ingress controllers.
+
 ### APIScheme Custom Resource
 
 The APIScheme resource instructs the operator to create the admin API endpoint. The specification of the resource is explained below:

--- a/controllers/publishingstrategy/publishingstrategy_controller_test.go
+++ b/controllers/publishingstrategy/publishingstrategy_controller_test.go
@@ -1,15 +1,17 @@
 package publishingstrategy
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"reflect"
 	"testing"
 	"time"
-
-	"context"
 
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	"github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -462,6 +464,92 @@ func TestEnsureIngressController(t *testing.T) {
 
 }
 
+func TestEnsureNoNewSecondIngressCreated(t *testing.T) {
+	tests := []struct {
+		Name                    string
+		ApplicationIngresses    []cloudingressv1alpha1.ApplicationIngress
+		OwnedIngressExistingMap map[string]bool
+		Resp                    reconcile.Result
+		ErrorExpected           bool
+	}{
+		{
+			Name: "it blocks the creation of a new non-default application ingress",
+			ApplicationIngresses: []cloudingressv1alpha1.ApplicationIngress{
+				{
+					Default:       true,
+					DNSName:       "my.unit.test",
+					Listening:     "external",
+					Certificate:   corev1.SecretReference{Name: "test-cert-bundle-secret", Namespace: "openshift-ingress-operator"},
+					RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+				{
+					Default:       false,
+					DNSName:       "my2.unit.test",
+					Listening:     "external",
+					Certificate:   corev1.SecretReference{Name: "test-cert-bundle-secret", Namespace: "openshift-ingress-operator"},
+					RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+			},
+			OwnedIngressExistingMap: map[string]bool{
+				"default": false,
+			},
+			Resp:          reconcile.Result{},
+			ErrorExpected: true,
+		},
+		{
+			Name: "it allows deletion of existing apps2 ingresses",
+			ApplicationIngresses: []cloudingressv1alpha1.ApplicationIngress{
+				{
+					Default:       true,
+					DNSName:       "my.unit.test",
+					Listening:     "external",
+					Certificate:   corev1.SecretReference{Name: "test-cert-bundle-secret", Namespace: "openshift-ingress-operator"},
+					RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+			},
+			OwnedIngressExistingMap: map[string]bool{
+				"default": false,
+				"my2":     false,
+			},
+			Resp:          reconcile.Result{},
+			ErrorExpected: false,
+		},
+		{
+			Name: "allows for creating a new default ingress",
+			ApplicationIngresses: []cloudingressv1alpha1.ApplicationIngress{
+				{
+					Default:       true,
+					DNSName:       "my.unit.test",
+					Listening:     "external",
+					Certificate:   corev1.SecretReference{Name: "test-cert-bundle-secret", Namespace: "openshift-ingress-operator"},
+					RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+			},
+			OwnedIngressExistingMap: map[string]bool{},
+			Resp:                    reconcile.Result{},
+			ErrorExpected:           false,
+		},
+		{
+			Name:                 "allows for deleting a default ingress",
+			ApplicationIngresses: []cloudingressv1alpha1.ApplicationIngress{},
+			OwnedIngressExistingMap: map[string]bool{
+				"default": false,
+			},
+			Resp:          reconcile.Result{},
+			ErrorExpected: false,
+		},
+	}
+	for _, test := range tests {
+		result, err := ensureNoNewSecondIngressCreated(log, test.ApplicationIngresses, test.OwnedIngressExistingMap)
+		if err == nil && test.ErrorExpected || err != nil && !test.ErrorExpected {
+			t.Fatalf("Test [%v] return mismatch. Expect error? %t: Return %+v", test.Name, test.ErrorExpected, err)
+		}
+		if result != test.Resp {
+			t.Fatalf("Test [%v] FAILED. Expected Response %v. Got %v", test.Name, test.Resp, result)
+		}
+	}
+}
+
 func TestDeleteUnpublishedIngressControllers(t *testing.T) {
 	tests := []struct {
 		Name              string
@@ -658,6 +746,80 @@ func TestEnsurePatchableSpec(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultICOwnedByClusterIngressOperator(t *testing.T) {
+	tests := []struct {
+		Name                string
+		ExpectedFinalizers  []string
+		ExpectedAnnotations map[string]string
+		Resp                reconcile.Result
+		ClusterVersion      string
+		ClientErr           map[string]string // used to instruct the client to generate an error on k8sclient Update, Delete or Create
+		ErrorExpected       bool
+		ErrorReason         string
+	}{
+		{
+			Name:               "It disowns the default ingress controller",
+			ExpectedFinalizers: []string{ClusterIngressFinalizer},
+			ExpectedAnnotations: map[string]string{
+				"Owner":                             "cluster-ingress-operator",
+				IngressControllerDeleteLBAnnotation: "true",
+			},
+			ClusterVersion: "4.13.0",
+			Resp:           reconcile.Result{},
+			ErrorExpected:  false,
+		},
+		{
+			Name:           "Does not disown the default ingress controller if v<4.13",
+			ClusterVersion: "4.12.0",
+			Resp:           reconcile.Result{},
+			ErrorExpected:  true,
+		},
+		{
+			Name:           "Returns the client error if we cannot get the ingress controller",
+			ClientErr:      map[string]string{"on": "Get", "type": "InternalError"},
+			ClusterVersion: "4.12.0",
+			Resp:           reconcile.Result{},
+			ErrorExpected:  true,
+		},
+		{
+			Name:           "Returns the client error if we cannot patch the ingress controller",
+			ClientErr:      map[string]string{"on": "Patch", "type": "InternalError"},
+			ClusterVersion: "4.12.0",
+			Resp:           reconcile.Result{},
+			ErrorExpected:  true,
+		},
+	}
+	for _, test := range tests {
+		defer os.Unsetenv("CLUSTER_VERSION")
+
+		os.Setenv("CLUSTER_VERSION", test.ClusterVersion)
+		ic := makeIngressControllerCR("default", "external", []string{ClusterIngressFinalizer})
+
+		testClient, testScheme := setUpTestClient([]client.Object{ic}, []runtime.Object{}, test.ClientErr["on"], test.ClientErr["type"], test.ClientErr["target"])
+		r := &PublishingStrategyReconciler{Client: testClient, Scheme: testScheme}
+		result, err := r.ensureDefaultICOwnedByClusterIngressOperator(log)
+		// Reset the IC to the patched version post function call
+		_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: "default", Namespace: ingressControllerNamespace}, ic)
+
+		if err == nil && test.ErrorExpected || err != nil && !test.ErrorExpected {
+			t.Fatalf("Test [%v] return mismatch. Expect error? %t: Return %+v", test.Name, test.ErrorExpected, err)
+		}
+		if err != nil && test.ErrorExpected && test.ErrorReason != fmt.Sprint(k8serr.ReasonForError(err)) {
+			t.Fatalf("Test [%v] FAILED. Expected Error %v. Got %v", test.Name, test.ErrorReason, k8serr.ReasonForError(err))
+		}
+		if result != test.Resp {
+			t.Fatalf("Test [%v] FAILED. Expected Response %v. Got %v", test.Name, test.Resp, result)
+		}
+
+		if test.ExpectedAnnotations != nil && !reflect.DeepEqual(ic.Annotations, test.ExpectedAnnotations) {
+			t.Fatalf("Test [%v] FAILED. Expected Response %v. Got %v", test.Name, test.ExpectedAnnotations, ic.Annotations)
+		}
+		if test.ExpectedFinalizers != nil && !reflect.DeepEqual(ic.Finalizers, test.ExpectedFinalizers) {
+			t.Fatalf("Test [%v] FAILED. Expected Response %v. Got %v", test.Name, test.ExpectedFinalizers, ic.Finalizers)
+		}
+	}
+}
+
 func TestReconcileGCP(t *testing.T) {
 	defaultPublishingStrategy := &cloudingressv1alpha1.PublishingStrategy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -788,6 +950,120 @@ func TestReconcileGCP(t *testing.T) {
 
 		// Create the client with the scheme and objects, then wrap it in our custom client
 		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(test.RuntimeObj...).WithObjects(test.ClientObj...).Build()
+		testClient := &customClient{fakeClient, test.ClientErr["on"], test.ClientErr["type"], test.ClientErr["target"]}
+
+		r := &PublishingStrategyReconciler{Client: testClient, Scheme: testScheme}
+		result, err := r.Reconcile(context.TODO(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "publishingstrategy",
+				Namespace: "openshift-cloud-ingress-operator",
+			},
+		})
+
+		if err == nil && test.ErrorExpected || err != nil && !test.ErrorExpected {
+			t.Fatalf("Test [%v] return mismatch. Expect error? %t: Return %+v", test.Name, test.ErrorExpected, err)
+		}
+		if err != nil && test.ErrorExpected && test.ErrorReason != fmt.Sprint(k8serr.ReasonForError(err)) {
+			t.Fatalf("Test [%v] FAILED. Excepted Error %v. Got %v", test.Name, test.ErrorReason, k8serr.ReasonForError(err))
+		}
+		if result != test.Resp {
+			t.Fatalf("Test [%v] FAILED. Excepted Response %v. Got %v", test.Name, test.Resp, result)
+		}
+	}
+}
+
+func TestReconcileUserManagedIngressFeature(t *testing.T) {
+	tests := []struct {
+		Name             string
+		Resp             reconcile.Result
+		MakeClientObject func(ps *cloudingressv1alpha1.PublishingStrategy) []client.Object
+		RuntimeObj       []runtime.Object
+		ClientErr        map[string]string // used to instruct the client to generate an error on k8sclient Update, Delete or Create
+		ClusterVersion   string
+		ErrorExpected    bool
+		ErrorReason      string
+	}{
+		{
+			Name: "Ensure it returns an error if user is trying to add additional non-default application ingress",
+			Resp: reconcile.Result{},
+			MakeClientObject: func(ps *cloudingressv1alpha1.PublishingStrategy) []client.Object {
+				ps.SetLabels(map[string]string{
+					utils.ClusterLegacyIngressLabel: "false",
+				})
+				ps.Spec.ApplicationIngress = append(ps.Spec.ApplicationIngress, cloudingressv1alpha1.ApplicationIngress{
+					Default:       false,
+					DNSName:       "my2.unit.test",
+					Listening:     "internal",
+					RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+				})
+				return []client.Object{ps, makeAWSClassicIC("default", "internal", []string{ClusterIngressFinalizer})}
+			},
+			RuntimeObj:    []runtime.Object{&ingresscontroller.IngressControllerList{}},
+			ErrorExpected: true,
+		},
+		{
+			Name: "Returns an error if v>4.13 and we cannot disown default ingress",
+			Resp: reconcile.Result{},
+			MakeClientObject: func(ps *cloudingressv1alpha1.PublishingStrategy) []client.Object {
+				ps.SetLabels(map[string]string{
+					utils.ClusterLegacyIngressLabel: "false",
+				})
+				return []client.Object{ps, makeAWSClassicIC("default", "internal", []string{ClusterIngressFinalizer})}
+			},
+			RuntimeObj:     []runtime.Object{&ingresscontroller.IngressControllerList{}},
+			ClientErr:      map[string]string{"on": "Patch", "type": "InternalError"},
+			ClusterVersion: "4.13.1",
+			ErrorExpected:  true,
+			ErrorReason:    "InternalError",
+		},
+		{
+			Name: "Returns nil and exits if v>4.13 and successfully disowned ingress",
+			Resp: reconcile.Result{},
+			MakeClientObject: func(ps *cloudingressv1alpha1.PublishingStrategy) []client.Object {
+				ps.SetLabels(map[string]string{
+					utils.ClusterLegacyIngressLabel: "false",
+				})
+				return []client.Object{ps, makeAWSClassicIC("default", "internal", []string{ClusterIngressFinalizer})}
+			},
+			RuntimeObj:     []runtime.Object{&ingresscontroller.IngressControllerList{}},
+			ClusterVersion: "4.13.1",
+			ErrorExpected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		defaultPublishingStrategy := &cloudingressv1alpha1.PublishingStrategy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "publishingstrategy",
+				Namespace: "openshift-cloud-ingress-operator",
+			},
+			Spec: cloudingressv1alpha1.PublishingStrategySpec{
+				DefaultAPIServerIngress: cloudingressv1alpha1.DefaultAPIServerIngress{Listening: cloudingressv1alpha1.External},
+				ApplicationIngress: []cloudingressv1alpha1.ApplicationIngress{
+					{
+						Default:       true,
+						DNSName:       "my.unit.test",
+						Listening:     "internal",
+						RouteSelector: metav1.LabelSelector{MatchLabels: map[string]string{}},
+					},
+				},
+			},
+		}
+		defer os.Unsetenv("CLUSTER_VERSION")
+
+		os.Setenv("CLUSTER_VERSION", test.ClusterVersion)
+
+		// Create infrastructure object
+		infraObj := testutils.CreateInfraObject("basename", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
+		// Register all local CRDs with the scheme
+		clientObj := test.MakeClientObject(defaultPublishingStrategy)
+		testScheme := setupLocalV1alpha1Scheme(clientObj, test.RuntimeObj)
+		// Add the infra object to the scheme and the runtime objects
+		testScheme.AddKnownTypes(schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}, infraObj)
+		test.RuntimeObj = append(test.RuntimeObj, infraObj)
+
+		// Create the client with the scheme and objects, then wrap it in our custom client
+		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithRuntimeObjects(test.RuntimeObj...).WithObjects(clientObj...).Build()
 		testClient := &customClient{fakeClient, test.ClientErr["on"], test.ClientErr["type"], test.ClientErr["target"]}
 
 		r := &PublishingStrategyReconciler{Client: testClient, Scheme: testScheme}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -428,3 +428,30 @@ objects:
         name: cloud-ingress-operator
         namespace: openshift-ingress-operator
         apiGroup: rbac.authorization.k8s.io
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    annotations:
+      component-display-name: ${DISPLAY_NAME}
+      component-name: ${REPO_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-feature-labeller
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: In
+        values:
+          - "false"
+    resourceApplyMode: Sync
+    # https://gitlab.cee.redhat.com/service/uhc-clusters-service/tree/master/pkg/osd/ingress_service.go
+    # Where the name 'publishingstrategy' is defined
+    patch: >
+      {"kind": "PublishingStrategy", "apiVersion": "cloudingress.managed.openshift.io/v1alpha1", "metadata": {"name": "publishingstrategy", "labels": {"ext-managed.openshift.io/legacy-ingress-support": "false"}}}
+    patchType: merge

--- a/pkg/utils/feature.go
+++ b/pkg/utils/feature.go
@@ -1,0 +1,12 @@
+package utils
+
+var ClusterLegacyIngressLabel = "ext-managed.openshift.io/legacy-ingress-support"
+
+func HasUserManagedIngressFeature(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+	// Not having the label is assumed to mean that the deployment is a legacy cluster
+	legacyIngressLabel, labelExists := labels[ClusterLegacyIngressLabel]
+	return labelExists && legacyIngressLabel == "false"
+}

--- a/pkg/utils/feature_test.go
+++ b/pkg/utils/feature_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestHasUserManagedIngressFeature(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "It does not have the feature enabled if the label does not exist on the cluster",
+			args: args{
+				labels: nil,
+			},
+			want: false,
+		},
+		{
+			name: "It does not have the feature enabled if the label exists and is true",
+			args: args{
+				labels: map[string]string{
+					ClusterLegacyIngressLabel: "true",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "It has the feature enabled if the label exists and is false",
+			args: args{
+				labels: map[string]string{
+					ClusterLegacyIngressLabel: "false",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasUserManagedIngressFeature(tt.args.labels); got != tt.want {
+				t.Errorf("HasUserManagedIngressFeature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Based on this deprecation strategy: https://docs.google.com/document/d/1i0FqT_ZuCo29ZlkpXYh81nk-A-PPYUTXTZLQgsPV-G4/edit

Resolves https://issues.redhat.com/browse/OSD-17023

This pull request allows proposed in [SDE-1768](https://issues.redhat.com/browse/SDE-1768) to proceed. The crux of [SDE-1768](https://issues.redhat.com//browse/SDE-1768), as well as its sibling epics, is to deprecate the ability to create Red-Hat managed non-default IngressControllers. This involves some CIO changes, which I've outlined below. 

If feature enabled and >=v4.13:
- Disable `applicationIngress` completely in `PublishingStrategy`
- Transfer ownership of default ingress controller if v>=4.13 to `cluster-ingress-operator`
- Transfer finalisers of default ingress controller if v>=4.13 to `cluster-ingress-operator`
- Label `PublishingStrategy` with feature flag in syncset
If feature enabled and <v4.13:
- Disallow new 2nd non-default ingress controller
- Allow existing apps2 to be updated/deleted
- Only default ingress controller managed by cloud-ingress-operator
- Label `PublishingStrategy` with feature flag in syncset

The feature flag is one that we are also using here: https://github.com/openshift/custom-domains-operator/pull/108, that allows us to gradually introduce this feature cluster-wide. It uses a label on the Hive `ClusterDeployment`, similar to `uwm-disabled`, which gets applied to any resources that need to know about it. 

All test cases tested and working on stage:
https://gitlab.cee.redhat.com/-/snippets/6806