### PR TITLE
Use correct hive SSS patch syntax

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -449,9 +449,14 @@ objects:
         operator: In
         values:
           - "false"
-    resourceApplyMode: Sync
     # https://gitlab.cee.redhat.com/service/uhc-clusters-service/tree/master/pkg/osd/ingress_service.go
     # Where the name 'publishingstrategy' is defined
-    patch: >
-      {"kind": "PublishingStrategy", "apiVersion": "cloudingress.managed.openshift.io/v1alpha1", "metadata": {"name": "publishingstrategy", "labels": {"ext-managed.openshift.io/legacy-ingress-support": "false"}}}
-    patchType: merge
+    patches:
+    - apiVersion: cloudingress.managed.openshift.io/v1alpha1
+      kind: PublishingStrategy
+      name: publishingstrategy
+      namespace: openshift-cloud-ingress-operator
+      patch: >
+        {"metadata": {"labels": {"ext-managed.openshift.io/legacy-ingress-support": "false"}}}
+      patchType: merge
+    resourceApplyMode: Sync


### PR DESCRIPTION
Fixes an issue where the `SelectorSyncSet` patch that was used to let the Cloud Ingress Operator know that a cluster has the `legacy ingress` label was malformed. 

Correct syntax recommended [here](https://redhat-internal.slack.com/archives/CE3ETN3J8/p1689178206664249?thread_ts=1689148277.662989&cid=CE3ETN3J8)), and implemented in this PR.

Completely tested and confirmed to work with a stage cluster and `ClusterDeployment` [here](

This has now been tested using a test selectorsyncset [here](https://docs.google.com/document/d/1ViR9VdvEU9XWPanwluDV8qHZtPHloqY8KU9AQ63SbOw/edit) and confirmed to work. 