### PR TITLE
Ignore PS legacy ingress patch on STS/Privatelink

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -449,6 +449,14 @@ objects:
         operator: In
         values:
           - "false"
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - "true"
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - "true"
     # https://gitlab.cee.redhat.com/service/uhc-clusters-service/tree/master/pkg/osd/ingress_service.go
     # Where the name 'publishingstrategy' is defined
     patches:


### PR DESCRIPTION
To enable [SDE-1768](https://issues.redhat.com/browse/SDE-1768) for the `cloud-ingress-operator`, we need to patch the `PublishingStrategy` resource to let it know that it is using the new feature. 

The CIO is not deployed on STS or PrivateLink clusters, so the patch will need to be amended to ignore these.
Current failure message on STS (without patch):

    - failureMessage: 'failed to apply patch 0: the server doesn''t have a resource
        type "PublishingStrategy"'
      lastTransitionTime: "2023-07-18T23:44:55Z"
      name: cloud-ingress-operator-feature-labeller
      observedGeneration: 2
      result: Failure

This pull request amends the `cloud-ingress-operator-feature-labeller` to skip STS/PL clusters. 

Fixes https://issues.redhat.com/browse/OSD-17533

Verified and working here: https://gitlab.cee.redhat.com/-/snippets/6873
