### PR TITLE
Update dependencies in preparation for adding CPMS support

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,10 +114,12 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "cloud-ingress-operator-lock")
-	if err != nil {
-		setupLog.Error(err, "failed to setup leader lock")
-		os.Exit(1)
+	if enableLeaderElection {
+		err = leader.Become(ctx, "cloud-ingress-operator-lock")
+		if err != nil {
+			setupLog.Error(err, "failed to setup leader lock")
+			os.Exit(1)
+		}
 	}
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -259,11 +259,11 @@ func (ac *Client) setDefaultAPIPublic(ctx context.Context, kclient k8s.Client, i
 
 // getMasterNodeSubnets returns all the subnets for Machines with 'master' label.
 // return structure:
-// {
-//   public => subnetname,
-//   private => subnetname,
-// }
 //
+//	{
+//	  public => subnetname,
+//	  private => subnetname,
+//	}
 func getMasterNodeSubnets(kclient k8s.Client) (map[string]string, error) {
 	subnets := make(map[string]string)
 	machineList, err := baseutils.GetMasterMachines(kclient)
@@ -452,7 +452,7 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 	return false, nil
 }
 
-//getClusterRegion returns the installed cluster's AWS region
+// getClusterRegion returns the installed cluster's AWS region
 func getClusterRegion(kclient k8s.Client) (string, error) {
 	infra, err := baseutils.GetInfrastructureObject(kclient)
 	if err != nil {

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -33,7 +33,7 @@ func TestAWSProviderDecode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-
+			test := test
 			objs := []runtime.Object{&test.m}
 			mocks := testutils.NewTestMock(t, objs)
 			machineInfo := types.NamespacedName{

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -19,7 +19,7 @@ func TestNewClient(t *testing.T) {
 		"client_id": "123-abc.apps.googleusercontent.com",
 		"auth_uri": "https://accounts.google.com/o/oauth2/auth",
 		"token_uri": "http://localhost:8080/token"
-	  }`
+	  }` //#nosec G101 -- This is a false positive
 
 	infra := testutils.CreateGCPInfraObject("sut", testutils.DefaultAPIEndpoint, testutils.DefaultAPIEndpoint, testutils.DefaultRegionName)
 

--- a/pkg/cloudclient/gcp/private_test.go
+++ b/pkg/cloudclient/gcp/private_test.go
@@ -130,6 +130,7 @@ func TestGCPProviderDecodeEncode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
+			test := test
 			objs := []runtime.Object{&test.m}
 			mocks := testutils.NewTestMock(t, objs)
 			machineInfo := types.NamespacedName{

--- a/pkg/utils/machines.go
+++ b/pkg/utils/machines.go
@@ -4,19 +4,26 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	machinev1 "github.com/openshift/api/machine/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const masterMachineLabel string = "machine.openshift.io/cluster-api-machine-role"
+const (
+	masterMachineLabel  = "machine.openshift.io/cluster-api-machine-role"
+	machineApiNamespace = "openshift-machine-api"
+	cpmsName            = "cluster"
+)
 
 // GetMasterMachines returns a MachineList object whose .Items can be iterated
 // over to perform actions on/with information from each master machine object.
 func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
 	machineList := &machineapi.MachineList{}
 	listOptions := []client.ListOption{
-		client.InNamespace("openshift-machine-api"),
+		client.InNamespace(machineApiNamespace),
 		client.MatchingLabels{masterMachineLabel: "master"},
 	}
 	err := kclient.List(context.TODO(), machineList, listOptions...)
@@ -24,4 +31,20 @@ func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
 		return nil, err
 	}
 	return machineList, nil
+}
+
+func GetControlPlaneMachineSet(kclient client.Client) (*machinev1.ControlPlaneMachineSet, error) {
+	cpms := &machinev1.ControlPlaneMachineSet{}
+	key := client.ObjectKey{
+		Namespace: machineApiNamespace,
+		Name:      cpmsName,
+	}
+	err := kclient.Get(context.TODO(), key, cpms)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil // Nothing to do
+		}
+		return nil, fmt.Errorf("failed to get controlplanemachineset: %w", err)
+	}
+	return cpms, nil
 }


### PR DESCRIPTION
In order to support coming changes for CPMS, we needed to update some of our dependencies. This caused a whole mess of dependency issues that required @JoelSpeed 's help to untangle, which I believe is worthy of its own PR.

Most of this work has been superseded by https://github.com/openshift/cloud-ingress-operator/pull/310, but I think there's still some good prep work here for [OSD-14568](https://issues.redhat.com/browse/OSD-14568).