### PR TITLE
[OSD-14568] Handle CPMS enabled / inactive clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ build/_output
 # for Jenkins credentials to work
 .docker/
 saas-cloud-ingress-operator-bundle
+launch.json

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 
 ENV USER_UID=1001 \
     USER_NAME=cloud-ingress-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
+	"github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestNewClient(t *testing.T) {
@@ -92,4 +96,74 @@ func TestHealthcheck(t *testing.T) {
 		t.Error("err occured while performing healthcheck:", err)
 	}
 
+}
+
+func TestCpmsBranching(t *testing.T) {
+	fakeAwsMachine := machinev1beta1.AWSMachineProviderConfig{
+		LoadBalancers: []machinev1beta1.LoadBalancerReference{
+			{
+				Name: "internal-lb",
+				Type: "NLB",
+			},
+			{
+				Name: "removal-lb",
+				Type: "NLB",
+			}},
+	}
+	bytes, _ := utils.ConvertToRawBytes(fakeAwsMachine)
+	fakeCpms := machinev1.ControlPlaneMachineSet{
+		TypeMeta:   v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{Name: "cluster", Namespace: "openshift-machine-api"},
+		Spec: machinev1.ControlPlaneMachineSetSpec{
+			State:    machinev1.ControlPlaneMachineSetStateActive,
+			Replicas: aws.Int32(3),
+			Strategy: machinev1.ControlPlaneMachineSetStrategy{Type: ""},
+			Selector: v1.LabelSelector{},
+			Template: machinev1.ControlPlaneMachineSetTemplate{
+				MachineType: machinev1.OpenShiftMachineV1Beta1MachineType,
+				OpenShiftMachineV1Beta1Machine: &machinev1.OpenShiftMachineV1Beta1MachineTemplate{
+					FailureDomains: machinev1.FailureDomains{
+						Platform: "aws",
+						AWS:      &[]machinev1.AWSFailureDomain{},
+					},
+					ObjectMeta: machinev1.ControlPlaneMachineSetTemplateObjectMeta{},
+					Spec: machinev1beta1.MachineSpec{
+						ObjectMeta: machinev1beta1.ObjectMeta{
+							Name:      "awsmachine",
+							Namespace: "openshift-machine-api",
+						},
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &runtime.RawExtension{
+								Raw:    bytes,
+								Object: nil,
+							},
+						},
+						ProviderID: aws.String("aws"),
+					},
+				},
+			},
+		},
+	}
+	objs := []runtime.Object{&fakeCpms}
+	mocks := testutils.NewTestMock(t, objs)
+	f := getLoadBalancerRemovalFunc(context.TODO(), mocks.FakeKubeClient, nil, &fakeCpms)
+	err := f("removal-lb")
+	if err != nil {
+		t.Errorf("Removing load balancer from cluster failed: %v", err)
+	}
+	updatedCpms := &machinev1.ControlPlaneMachineSet{}
+	err = mocks.FakeKubeClient.Get(context.TODO(), client.ObjectKey{
+		Namespace: "openshift-machine-api",
+		Name:      "cluster",
+	}, updatedCpms)
+	if err != nil {
+		t.Errorf("Could not get cpms again.")
+	}
+	spec, err := utils.ConvertFromRawExtension[machinev1beta1.AWSMachineProviderConfig](updatedCpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value)
+	if err != nil {
+		t.Errorf("Could not convert cpms rawextension.")
+	}
+	if len(spec.LoadBalancers) != 1 {
+		t.Errorf("Removing load balancer from cluster did not leave only 1 lb behind: %v", spec.LoadBalancers)
+	}
 }

--- a/pkg/cloudclient/aws/aws_test.go
+++ b/pkg/cloudclient/aws/aws_test.go
@@ -98,7 +98,7 @@ func TestHealthcheck(t *testing.T) {
 
 }
 
-func TestCpmsBranching(t *testing.T) {
+func TestCpmsLbRemoval(t *testing.T) {
 	fakeAwsMachine := machinev1beta1.AWSMachineProviderConfig{
 		LoadBalancers: []machinev1beta1.LoadBalancerReference{
 			{
@@ -146,8 +146,7 @@ func TestCpmsBranching(t *testing.T) {
 	}
 	objs := []runtime.Object{&fakeCpms}
 	mocks := testutils.NewTestMock(t, objs)
-	f := getLoadBalancerRemovalFunc(context.TODO(), mocks.FakeKubeClient, nil, &fakeCpms)
-	err := f("removal-lb")
+	err := removeLoadBalancerCPMS(context.TODO(), mocks.FakeKubeClient, "removal-lb", &fakeCpms)
 	if err != nil {
 		t.Errorf("Removing load balancer from cluster failed: %v", err)
 	}

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -855,13 +855,6 @@ func (ac *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 		return "", "", err
 	}
 	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
-	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateInactive {
-		err := baseutils.RemoveCPMSAndAwaitMachineRemoval(ctx, kclient, cpms)
-		if err != nil {
-			log.Error(err, "Failed removing CPMS")
-			return "", "", err
-		}
-	}
 	var intDNSName, intHostedZoneID, lbName string
 	for _, networkLoadBalancer := range nlbs {
 		if networkLoadBalancer.scheme == "internet-facing" {
@@ -1136,9 +1129,9 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 	var remainingLoadBalancers []machinev1beta1.LoadBalancerReference
 	for _, lb := range spec.LoadBalancers {
 		if lb.Name == lbName {
-			log.Info("Removing loadbalancer %s from CPMs\n", lbName)
+			log.Info("Removing loadbalancer %s from CPMs", "load-balancer-name", lbName)
 		} else {
-			log.Info("Keeping loadbalancer %s from CPMs\n", lb.Name)
+			log.Info("Keeping loadbalancer %s from CPMs", "load-balancer-name", lb.Name)
 			remainingLoadBalancers = append(remainingLoadBalancers, lb)
 		}
 	}

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -856,7 +856,11 @@ func (ac *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 	}
 	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
 	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateInactive {
-		baseutils.RemoveCPMSAndAwaitMachineRemoval(ctx, kclient, cpms)
+		err := baseutils.RemoveCPMSAndAwaitMachineRemoval(ctx, kclient, cpms)
+		if err != nil {
+			log.Error(err, "Failed removing CPMS")
+			return "", "", err
+		}
 	}
 	var intDNSName, intHostedZoneID, lbName string
 	for _, networkLoadBalancer := range nlbs {

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -850,9 +851,18 @@ func (ac *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 	if err != nil {
 		return "", "", err
 	}
-	cpms, err := baseutils.GetControlPlaneMachineSet(kclient)
+	var cpms *machinev1.ControlPlaneMachineSet
+	cpms, err = baseutils.GetControlPlaneMachineSet(kclient)
 	if err != nil {
-		return "", "", err
+		if !k8serrors.IsNotFound(err) {
+			return "", "", err
+		}
+		// If there is no CPMS we handle it as an inactive one.
+		cpms = &machinev1.ControlPlaneMachineSet{
+			Spec: machinev1.ControlPlaneMachineSetSpec{
+				State: machinev1.ControlPlaneMachineSetStateInactive,
+			},
+		}
 	}
 	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
 	var intDNSName, intHostedZoneID, lbName string
@@ -1121,6 +1131,7 @@ func removeLoadBalancerMachineSet(ctx context.Context, kclient k8s.Client, lbNam
 }
 
 func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName string, cpms *machinev1.ControlPlaneMachineSet) error {
+	cpmsPatch := k8s.MergeFrom(cpms.DeepCopy())
 	rawExtension := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value
 	spec, err := baseutils.ConvertFromRawExtension[machinev1beta1.AWSMachineProviderConfig](rawExtension)
 	if err != nil {
@@ -1141,7 +1152,7 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 		return err
 	}
 	cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw = extension
-	err = kclient.Update(ctx, cpms)
+	err = kclient.Patch(ctx, cpms, cpmsPatch)
 	if err != nil {
 		return fmt.Errorf("could not update CPMS: %v", err)
 	}
@@ -1151,7 +1162,56 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 func getLoadBalancerRemovalFunc(ctx context.Context, kclient k8s.Client, masterList *machinev1beta1.MachineList, cpms *machinev1.ControlPlaneMachineSet) func(string) error {
 	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateActive {
 		return func(lbName string) error {
-			return removeLoadBalancerCPMS(ctx, kclient, lbName, cpms)
+			log.Info("Removing active CPMS")
+			err := baseutils.DeleteCPMS(ctx, kclient, cpms)
+			if err != nil {
+				log.Error(err, "failed to delete CPMS")
+				return err
+			}
+			// It seems this has to actually do both - the machine api is not
+			// able to remove machines that still reference a LB that does not
+			// exist:
+			// E1117 14:42:49.349992       1 controller.go:255] fbergman-14568-tn7t8-master-0: failed to delete machine: fbergman-14568-tn7t8-master-0: reconciler failed to Delete machine: failed to updated update load balancers: LoadBalancerNotFound: Load balancers '[fbergman-14568-tn7t8-ext]' not found
+			log.Info("Updating controlplane machines")
+			err = removeLoadBalancerMachineSet(ctx, kclient, lbName, masterList)
+			if err != nil {
+				log.Error(err, "failed to remove load balancer from machines")
+				return err
+			}
+			go func() {
+				maxRetries := 5
+				for {
+					time.Sleep(60 * time.Second)
+					log.Info("Retrieve cpms again")
+					cpms, err := baseutils.GetControlPlaneMachineSet(kclient)
+					if err != nil {
+						log.Error(err, "could not get updated CPMS")
+					}
+					log.Info("Removing LB from cpms")
+					err = removeLoadBalancerCPMS(ctx, kclient, lbName, cpms)
+					if err != nil {
+						log.Error(err, "failed to update CPMS")
+					}
+					log.Info("Retrieve cpms again")
+					cpms, err = baseutils.GetControlPlaneMachineSet(kclient)
+					if err != nil {
+						log.Error(err, "Could not retrieve CPMS")
+					}
+					err = baseutils.SetCPMSActive(context.Background(), kclient, cpms)
+					if err != nil {
+						log.Error(err, "Could not set CPMS active")
+					} else {
+						break
+					}
+					if maxRetries == 0 {
+						log.Info("Could not set CPMS back to active after 5 attempts")
+						break
+					}
+					maxRetries = maxRetries - 1
+				}
+			}()
+			// Don't fail the following steps - setting CPMS back to active will be tried again
+			return nil
 		}
 	} else {
 		return func(lbName string) error {

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -1,19 +1,13 @@
 package gcp
 
 import (
-	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	machinev1 "github.com/openshift/api/machine/v1"
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cloud-ingress-operator/config"
 	"github.com/openshift/cloud-ingress-operator/pkg/testutils"
-	"github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestNewClient(t *testing.T) {
@@ -48,70 +42,5 @@ func TestNewClient(t *testing.T) {
 
 	if cli == nil {
 		t.Error("cli should have been initialized")
-	}
-}
-
-func TestCpmsBranching(t *testing.T) {
-	fakeAwsMachine := machinev1beta1.GCPMachineProviderSpec{
-		TargetPools: []string{
-			"internal-lb",
-			"removal-lb",
-		},
-	}
-	bytes, _ := utils.ConvertToRawBytes(fakeAwsMachine)
-	fakeCpms := machinev1.ControlPlaneMachineSet{
-		TypeMeta:   v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{Name: "cluster", Namespace: "openshift-machine-api"},
-		Spec: machinev1.ControlPlaneMachineSetSpec{
-			State:    machinev1.ControlPlaneMachineSetStateActive,
-			Replicas: aws.Int32(3),
-			Strategy: machinev1.ControlPlaneMachineSetStrategy{Type: ""},
-			Selector: v1.LabelSelector{},
-			Template: machinev1.ControlPlaneMachineSetTemplate{
-				MachineType: machinev1.OpenShiftMachineV1Beta1MachineType,
-				OpenShiftMachineV1Beta1Machine: &machinev1.OpenShiftMachineV1Beta1MachineTemplate{
-					FailureDomains: machinev1.FailureDomains{
-						Platform: "gcp",
-						GCP:      &[]machinev1.GCPFailureDomain{},
-					},
-					ObjectMeta: machinev1.ControlPlaneMachineSetTemplateObjectMeta{},
-					Spec: machinev1beta1.MachineSpec{
-						ObjectMeta: machinev1beta1.ObjectMeta{
-							Name:      "awsmachine",
-							Namespace: "openshift-machine-api",
-						},
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &runtime.RawExtension{
-								Raw:    bytes,
-								Object: nil,
-							},
-						},
-						ProviderID: aws.String("gcp"),
-					},
-				},
-			},
-		},
-	}
-	objs := []runtime.Object{&fakeCpms}
-	mocks := testutils.NewTestMock(t, objs)
-	f := getLoadBalancerRemovalFunc(context.TODO(), mocks.FakeKubeClient, nil, &fakeCpms)
-	err := f("removal-lb")
-	if err != nil {
-		t.Errorf("Removing load balancer from cluster failed: %v", err)
-	}
-	updatedCpms := &machinev1.ControlPlaneMachineSet{}
-	err = mocks.FakeKubeClient.Get(context.TODO(), client.ObjectKey{
-		Namespace: "openshift-machine-api",
-		Name:      "cluster",
-	}, updatedCpms)
-	if err != nil {
-		t.Errorf("Could not get cpms again.")
-	}
-	spec, err := utils.ConvertFromRawExtension[machinev1beta1.GCPMachineProviderSpec](updatedCpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value)
-	if err != nil {
-		t.Errorf("Could not convert cpms rawextension.")
-	}
-	if len(spec.TargetPools) != 1 {
-		t.Errorf("Removing load balancer from cluster did not leave only 1 lb behind: %v", spec.TargetPools)
 	}
 }

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -289,13 +289,6 @@ func (gc *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 		return "", err
 	}
 	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
-	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateInactive {
-		err := baseutils.RemoveCPMSAndAwaitMachineRemoval(ctx, kclient, cpms)
-		if err != nil {
-			log.Error(err, "Failed removing CPMS")
-			return "", err
-		}
-	}
 	extNLBName := gc.clusterName + "-api"
 	intLBName := gc.clusterName + "-api-internal"
 	var intIPAddress, lbName string
@@ -540,9 +533,9 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 	var remainingLoadBalancers []string
 	for _, lb := range spec.TargetPools {
 		if lb == lbName {
-			log.Info("Removing loadbalancer %s from CPMs\n", lbName)
+			log.Info("Removing loadbalancer from CPMs", "load-balancer-name", lbName)
 		} else {
-			log.Info("Keeping loadbalancer %s from CPMs\n", lb)
+			log.Info("Keeping loadbalancer in CPMs", "load-balancer-name", lbName)
 			remainingLoadBalancers = append(remainingLoadBalancers, lb)
 		}
 	}

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -6,17 +6,20 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"net/http"
 	"reflect"
+
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	"google.golang.org/api/compute/v1"
 	gdnsv1 "google.golang.org/api/dns/v1"
 	"google.golang.org/api/googleapi"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
+	baseutils "github.com/openshift/cloud-ingress-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -273,6 +276,22 @@ func (gc *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 		return "", err
 	}
 
+	// Detect if this is a CPMS active/inactive cluster and choose the right strategy:
+	// 1. Remove the CPMS if needed
+	// 2. Remove the LBs
+	// 3. Readd the CPMS if needed
+	masterList, err := baseutils.GetMasterMachines(kclient)
+	if err != nil {
+		return "", "", err
+	}
+	cpms, err := baseutils.GetControlPlaneMachineSet(kclient)
+	if err != nil {
+		return "", "", err
+	}
+	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
+	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateInactive {
+		baseutils.RemoveCPMSAndAwaitMachineRemoval(ctx, kclient, cpms)
+	}
 	extNLBName := gc.clusterName + "-api"
 	intLBName := gc.clusterName + "-api-internal"
 	var intIPAddress, lbName string
@@ -287,7 +306,7 @@ func (gc *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 			if err != nil {
 				return "", fmt.Errorf("Failed to delete ForwardingRule for external load balancer %v: %v", lb.Name, err)
 			}
-			err = removeGCPLBFromMasterMachines(kclient, lbName, gc.masterList)
+			err = removalClosure(lbName)
 			if err != nil {
 				return "", err
 			}
@@ -506,4 +525,44 @@ func getClusterDNS(kclient k8s.Client) (*configv1.DNS, error) {
 	}
 
 	return dns, nil
+}
+
+func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName string, cpms *machinev1.ControlPlaneMachineSet) error {
+	rawExtension := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value
+	spec, err := baseutils.ConvertFromRawExtension[machineapi.GCPMachineProviderSpec](rawExtension)
+	if err != nil {
+		return err
+	}
+	var remainingLoadBalancers []string
+	for _, lb := range spec.TargetPools {
+		if lb == lbName {
+			log.Info("Removing loadbalancer %s from CPMs\n", lbName)
+		} else {
+			log.Info("Keeping loadbalancer %s from CPMs\n", lb)
+			remainingLoadBalancers = append(remainingLoadBalancers, lb)
+		}
+	}
+	spec.TargetPools = remainingLoadBalancers
+	extension, err := baseutils.ConvertToRawBytes(spec)
+	if err != nil {
+		return err
+	}
+	cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw = extension
+	err = kclient.Update(ctx, cpms)
+	if err != nil {
+		return fmt.Errorf("could not update CPMS: %v", err)
+	}
+	return nil
+}
+
+func getLoadBalancerRemovalFunc(ctx context.Context, kclient k8s.Client, masterList *machinev1beta1.MachineList, cpms *machinev1.ControlPlaneMachineSet) func(string) error {
+	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateActive {
+		return func(lbName string) error {
+			return removeLoadBalancerCPMS(ctx, kclient, lbName, cpms)
+		}
+	} else {
+		return func(lbName string) error {
+			return removeGCPLBFromMasterMachines(kclient, lbName, masterList)
+		}
+	}
 }

--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	"google.golang.org/api/compute/v1"
@@ -284,9 +286,19 @@ func (gc *Client) removeLoadBalancerFromMasterNodes(ctx context.Context, kclient
 	if err != nil {
 		return "", err
 	}
-	cpms, err := baseutils.GetControlPlaneMachineSet(kclient)
+	var cpms *machinev1.ControlPlaneMachineSet
+	cpms, err = baseutils.GetControlPlaneMachineSet(kclient)
 	if err != nil {
-		return "", err
+		if !errors.IsNotFound(err) {
+			return "", err
+		}
+
+		// If there is no CPMS we handle it as an inactive one.
+		cpms = &machinev1.ControlPlaneMachineSet{
+			Spec: machinev1.ControlPlaneMachineSetSpec{
+				State: machinev1.ControlPlaneMachineSetStateInactive,
+			},
+		}
 	}
 	removalClosure := getLoadBalancerRemovalFunc(ctx, kclient, masterList, cpms)
 	extNLBName := gc.clusterName + "-api"
@@ -525,6 +537,7 @@ func getClusterDNS(kclient k8s.Client) (*configv1.DNS, error) {
 }
 
 func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName string, cpms *machinev1.ControlPlaneMachineSet) error {
+	cpmsPatch := k8s.MergeFrom(cpms.DeepCopy())
 	rawExtension := cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value
 	spec, err := baseutils.ConvertFromRawExtension[machineapi.GCPMachineProviderSpec](rawExtension)
 	if err != nil {
@@ -545,7 +558,7 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 		return err
 	}
 	cpms.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Raw = extension
-	err = kclient.Update(ctx, cpms)
+	err = kclient.Patch(ctx, cpms, cpmsPatch)
 	if err != nil {
 		return fmt.Errorf("could not update CPMS: %v", err)
 	}
@@ -555,7 +568,50 @@ func removeLoadBalancerCPMS(ctx context.Context, kclient k8s.Client, lbName stri
 func getLoadBalancerRemovalFunc(ctx context.Context, kclient k8s.Client, masterList *machineapi.MachineList, cpms *machinev1.ControlPlaneMachineSet) func(string) error {
 	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateActive {
 		return func(lbName string) error {
-			return removeLoadBalancerCPMS(ctx, kclient, lbName, cpms)
+			err := baseutils.DeleteCPMS(ctx, kclient, cpms)
+			if err != nil {
+				log.Error(err, "failed to delete CPMS")
+				return err
+			}
+			err = removeGCPLBFromMasterMachines(kclient, lbName, masterList)
+			if err != nil {
+				log.Error(err, "faild to remove load balancer from machines")
+				return err
+			}
+			go func() {
+				maxRetries := 5
+				for {
+					time.Sleep(60 * time.Second)
+					log.Info("Retrieve cpms again")
+					cpms, err = baseutils.GetControlPlaneMachineSet(kclient)
+					if err != nil {
+						log.Error(err, "could not get updated CPMS")
+					}
+					log.Info("Removing LB from cpms")
+					err = removeLoadBalancerCPMS(ctx, kclient, lbName, cpms)
+					if err != nil {
+						log.Error(err, "failed to update CPMS")
+					}
+					log.Info("Retrieve cpms again")
+					cpms, err = baseutils.GetControlPlaneMachineSet(kclient)
+					if err != nil {
+						log.Error(err, "Could not retrieve CPMS")
+					}
+					err = baseutils.SetCPMSActive(context.Background(), kclient, cpms)
+					if err != nil {
+						log.Error(err, "Could not set CPMS active")
+					} else {
+						break
+					}
+					if maxRetries == 0 {
+						log.Info("Could not set CPMS back to active after 5 attempts")
+						break
+					}
+					maxRetries = maxRetries - 1
+				}
+			}()
+			// Don't fail the following steps - setting CPMS back to active will be tried again
+			return nil
 		}
 	} else {
 		return func(lbName string) error {

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -9,6 +9,7 @@ import (
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 
+	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,6 +104,9 @@ func NewTestMock(t *testing.T, localObjs []runtime.Object) *Mocks {
 	}
 	if err := ingresscontroller.AddToScheme(s); err != nil {
 		t.Fatalf("Unable to add route scheme: (%v)", err)
+	}
+	if err := machinev1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add machine scheme: (%v)", err)
 	}
 	s.AddKnownTypes(machinev1beta1.SchemeGroupVersion,
 		&machinev1beta1.AWSMachineProviderConfig{},

--- a/pkg/utils/machines.go
+++ b/pkg/utils/machines.go
@@ -10,11 +10,8 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -77,77 +74,4 @@ func ConvertToRawBytes(t interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("could not marshal provided type: %v", err)
 	}
 	return raw, nil
-}
-
-// This function will:
-// 1. Remove the CPMS
-// 2. Modify the machines in the non-CPMS usage way.
-// 3. Wait until N machines (= number of controlplane machines) have been completely deleted
-// 4. Recreate the CPMS
-func RemoveCPMSAndAwaitMachineRemoval(ctx context.Context, kclient client.Client, cpms *machinev1.ControlPlaneMachineSet) error {
-	log.Info("Removing INACTIVE CPMS to allow machine modifications")
-	err := kclient.Delete(ctx, cpms)
-	if err != nil {
-		log.Error(err, "Removing CPMS failed")
-		return err
-	}
-	// This must run async, if this blocks the cluster will break itself,
-	// because the API connectivity will break without the changes happening
-	// later (e.g. updating Route53)
-	go func() {
-		// Inside the goroutine retrieve the list of masters instead of closing
-		// over it. Pointers could easily point to wrong data otherwise.
-		masterList, err := GetMasterMachines(kclient)
-		if err != nil {
-			log.Error(err, "Could not get master machines")
-			return
-		}
-		log.Info("Waiting for master machines to be removed and recreate CPMS at the end.")
-		scheme := runtime.NewScheme()
-		err = machinev1.AddToScheme(scheme)
-		if err != nil {
-			log.Error(err, "Could not add machinev1 api to scheme")
-			return
-		}
-		err = machineapi.AddToScheme(scheme)
-		if err != nil {
-			log.Error(err, "Could not add machinev1beta1 api to scheme")
-			return
-		}
-		watchClient, err := client.NewWithWatch(config.GetConfigOrDie(), client.Options{
-			Scheme: scheme,
-		})
-		if err != nil {
-			log.Error(err, "Could not create watcher client")
-			return
-		}
-		watcher, err := watchClient.Watch(ctx, masterList)
-		if err != nil {
-			log.Error(err, "Could not create watch")
-			return
-		}
-		removedMachines := 0
-		totalMachines := len(masterList.Items)
-		for event := range watcher.ResultChan() {
-			switch event.Type {
-			case watch.Deleted:
-				removedMachines += 1
-				if removedMachines == totalMachines {
-					// TODO: With Luck this is good enough, as all new machines should be 'good' for the CPMS?
-					log.Info("All master machines have been removed now.")
-					watcher.Stop()
-				}
-			}
-		}
-		// Remove fields that might prevent recreation
-		cpms.Status = machinev1.ControlPlaneMachineSetStatus{}
-		cpms.CreationTimestamp = v1.Time{}
-		cpms.ResourceVersion = ""
-		// At least always attempt to recreate the cpms
-		err = kclient.Create(ctx, cpms)
-		if err != nil {
-			log.Error(err, "Could not recreate CPMS")
-		}
-	}()
-	return nil
 }

--- a/pkg/utils/machines.go
+++ b/pkg/utils/machines.go
@@ -4,12 +4,30 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const masterMachineLabel string = "machine.openshift.io/cluster-api-machine-role"
+const (
+	masterMachineLabel  string = "machine.openshift.io/cluster-api-machine-role"
+	machineApiNamespace string = "openshift-machine-api"
+	cpmsName            string = "cluster"
+)
+
+var (
+	log = logf.Log.WithName("baseutils")
+)
 
 // GetMasterMachines returns a MachineList object whose .Items can be iterated
 // over to perform actions on/with information from each master machine object.
@@ -24,4 +42,143 @@ func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
 		return nil, err
 	}
 	return machineList, nil
+}
+
+func GetControlPlaneMachineSet(kclient client.Client) (*machinev1.ControlPlaneMachineSet, error) {
+	cpms := &machinev1.ControlPlaneMachineSet{}
+	key := client.ObjectKey{
+		Namespace: machineApiNamespace,
+		Name:      cpmsName,
+	}
+	err := kclient.Get(context.TODO(), key, cpms)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil // Nothing to do
+		}
+		return nil, fmt.Errorf("failed to get controlplanemachineset: %w", err)
+	}
+	return cpms, nil
+}
+
+func ConvertFromRawExtension[T any](extension *runtime.RawExtension) (*T, error) {
+	t := new(T)
+	if extension == nil {
+		return t, fmt.Errorf("can not convert nil to type")
+	}
+	if err := json.Unmarshal(extension.Raw, &t); err != nil {
+		return t, fmt.Errorf("error unmarshalling providerSpec: %v", err)
+	}
+	return t, nil
+}
+
+func ConvertToRawBytes(t interface{}) ([]byte, error) {
+	raw, err := json.Marshal(t)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal provided type: %v", err)
+	}
+	return raw, nil
+}
+
+// This function will:
+// 1. Remove the CPMS
+// 2. Modify the machines in the non-CPMS usage way.
+// 3. Wait until N machines (= number of controlplane machines) have been completely deleted
+// 4. Recreate the CPMS
+func RemoveCPMSAndAwaitMachineRemoval(ctx context.Context, kclient client.Client, cpms *machinev1.ControlPlaneMachineSet) error {
+	log.Info("Removing INACTIVE CPMS to allow machine modifications")
+	err := kclient.Delete(ctx, cpms)
+	if err != nil {
+		return err
+	}
+	// This must run async, if this blocks the cluster will break itself,
+	// because the API connectivity will break without the changes happening
+	// later (e.g. updating Route53)
+	go func() {
+		// Inside the goroutine retrieve the list of masters instead of closing
+		// over it. Pointers could easily point to wrong data otherwise.
+		masterList, err := GetMasterMachines(kclient)
+		if err != nil {
+			log.Error(err, "Could not get master machines")
+		}
+		log.Info("Waiting for master machines to be removed and recreate CPMS at the end.")
+		scheme := runtime.NewScheme()
+		err = machinev1.AddToScheme(scheme)
+		if err != nil {
+			log.Error(err, "Could not add machinev1 api to scheme")
+		}
+		err = machineapi.AddToScheme(scheme)
+		if err != nil {
+			log.Error(err, "Could not add machinev1beta1 api to scheme")
+		}
+		watchClient, err := client.NewWithWatch(config.GetConfigOrDie(), client.Options{
+			Scheme: scheme,
+		})
+		if err != nil {
+			log.Error(err, "Could not create watcher client")
+		}
+		watcher, err := watchClient.Watch(ctx, masterList)
+		if err != nil {
+			log.Error(err, "Could not create watch")
+		}
+		removedMachines := 0
+		totalMachines := len(masterList.Items)
+		for event := range watcher.ResultChan() {
+			switch event.Type {
+			case watch.Deleted:
+				removedMachines += 1
+				if removedMachines == totalMachines {
+					// TODO: With Luck this is good enough, as all new machines should be 'good' for the CPMS?
+					log.Info("All master machines have been removed now.")
+					watcher.Stop()
+				}
+			}
+		}
+		// Remove fields that might prevent recreation
+		cpms.Status = machinev1.ControlPlaneMachineSetStatus{}
+		cpms.CreationTimestamp = v1.Time{}
+		cpms.ResourceVersion = ""
+		// At least always attempt to recreate the cpms
+		err = kclient.Create(ctx, cpms)
+		if err != nil {
+			log.Error(err, "Could not recreate CPMS")
+		}
+	}()
+	err = removalClosure()
+	if err != nil {
+		return err
+	}
+
+	scheme := runtime.NewScheme()
+	err = machinev1.AddToScheme(scheme)
+	if err != nil {
+		return err
+	}
+	err = machineapi.AddToScheme(scheme)
+	if err != nil {
+		return err
+	}
+	watchClient, err := client.NewWithWatch(config.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return err
+	}
+	watcher, err := watchClient.Watch(ctx, masterNodes)
+	if err != nil {
+		return err
+	}
+	removedMachines := 0
+	totalMachines := len(masterNodes.Items)
+	for event := range watcher.ResultChan() {
+		switch event.Type {
+		case watch.Deleted:
+			removedMachines += 1
+			if removedMachines == totalMachines {
+				// TODO: With Luck this is good enough, as all new machines should be 'good' for the CPMS?
+				log.Info("All master machines have been removed now.")
+				watcher.Stop()
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/utils/machines.go
+++ b/pkg/utils/machines.go
@@ -9,21 +9,14 @@ import (
 
 	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	masterMachineLabel  string = "machine.openshift.io/cluster-api-machine-role"
 	machineApiNamespace string = "openshift-machine-api"
 	cpmsName            string = "cluster"
-)
-
-var (
-	log = logf.Log.WithName("baseutils")
 )
 
 // GetMasterMachines returns a MachineList object whose .Items can be iterated
@@ -41,6 +34,7 @@ func GetMasterMachines(kclient client.Client) (*machineapi.MachineList, error) {
 	return machineList, nil
 }
 
+// GetControlPlaneMachineSet returns an OSD cluster's CPMS.
 func GetControlPlaneMachineSet(kclient client.Client) (*machinev1.ControlPlaneMachineSet, error) {
 	cpms := &machinev1.ControlPlaneMachineSet{}
 	key := client.ObjectKey{
@@ -49,12 +43,23 @@ func GetControlPlaneMachineSet(kclient client.Client) (*machinev1.ControlPlaneMa
 	}
 	err := kclient.Get(context.TODO(), key, cpms)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil // Nothing to do
-		}
 		return nil, fmt.Errorf("failed to get controlplanemachineset: %w", err)
 	}
 	return cpms, nil
+}
+
+// DeleteCPMS will remove the CPMS of the cluster - in OSD this will trigger the
+// CPMS to be recreated in an inactive state.
+func DeleteCPMS(ctx context.Context, kclient client.Client, cpms *machinev1.ControlPlaneMachineSet) error {
+	return kclient.Delete(ctx, cpms)
+}
+
+// SetCPMSActive will set a CPMS back to active.
+// This is required after calling DeleteCPMS, as it will recreate the CPMS in an inactive state.
+func SetCPMSActive(ctx context.Context, kclient client.Client, cpms *machinev1.ControlPlaneMachineSet) error {
+	patch := client.MergeFrom(cpms.DeepCopy())
+	cpms.Spec.State = machinev1.ControlPlaneMachineSetStateActive
+	return kclient.Patch(ctx, cpms, patch)
 }
 
 func ConvertFromRawExtension[T any](extension *runtime.RawExtension) (*T, error) {

--- a/resources/20_cloud-ingress-operator_machine.Role.yaml
+++ b/resources/20_cloud-ingress-operator_machine.Role.yaml
@@ -16,6 +16,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - machine.openshift.io
+  resources:
+  - controlplanemachinesets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - services


### PR DESCRIPTION
Add support to handle CPMS clusters.

In case of an inactive CPMS - remove the CPMS, modify the machines, recreate the CPMS.
In case of an active CPMS - modify the CPMS.