### PR TITLE
Add new CPMS related permissions to the olm deplyoment

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -221,6 +221,18 @@ objects:
         - patch
         - update
       - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
         - ""
         resources:
         - services


### PR DESCRIPTION
Fixes SA missing permissions from changes in https://github.com/openshift/cloud-ingress-operator/pull/314

Currently, the permissions put in the resources folder must be manually copied to the OLM manifests. This aligns the two so that the permissions will part of the role when OLM deploys the operator. 