### PR TITLE
 increase timeout for loadbalancer e2e test to 10 min

### DIFF
--- a/osde2e/cloud_ingress_operator_tests.go
+++ b/osde2e/cloud_ingress_operator_tests.go
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 			log.Printf("Old " + cioServiceName + " load balancer delete initiated")
 
 			ginkgo.By("Waiting for " + cioServiceName + " service reconcile")
-			err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, false, func(ctx2 context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 10*time.Minute, false, func(ctx2 context.Context) (bool, error) {
 				newLBName, err := getLBForService(ctx2, k8s, rhApiSvcNamespace, cioServiceName, false)
 				log.Printf("Looking for new load balancer")
 


### PR DESCRIPTION
rh-api load balancer may take longer than 5 minutes. increasing it to 10 minutes in AWS e2e test, this also matches the test for GCP. 