### PR TITLE
OSD-26173: don't deploy CIO on PSC clusters

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 ENV USER_UID=1001 \
     USER_NAME=cloud-ingress-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -47,6 +47,10 @@ objects:
         operator: NotIn
         values:
         - "true"
+      - key: api.openshift.com/private-service-connect
+        operator: NotIn
+        values:
+        - "true"
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-26173

CIO should not be deployed on PSC clusters, as those should not have a `rh-api` LB, similarly to privatelink.