### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,5 +16,7 @@ approvers:
 - sam-nguyen7
 - fahlmant
 - boranx
+- srep-functional-leads
+- srep-team-leads
 maintainers:
 - fahlmant


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to come by.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)