### PR TITLE
OSD-28295 enforce cpu and memory limits on the operators

### DIFF
--- a/deploy/50_cloud-ingress-operator.Deployment.yaml
+++ b/deploy/50_cloud-ingress-operator.Deployment.yaml
@@ -62,6 +62,7 @@ spec:
               cpu: "200m"
             limits:
               memory: "4G"
+              cpu: "200m"
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
[OSD-28295](https://issues.redhat.com//browse/OSD-28295) enforce cpu and memory limits on the operators.
 
In order to figure out the proper values to set I: 

Check the metrics on a long standing cluster in order to see the CPU and MEM consumption of the operator over a long period of time .

Created a test cluster, and performed the tests of setting the API to private and back to public to check the spikes of CPU and memory usage by the operator.

For the cloud ingress operator limits for CPU were the only ones missing.