### PR TITLE
Update deprecated wait.PollImmediate method

### DIFF
--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.It("ensures apischemes CR instance are present on cluster", func(ctx context.Context) {
-		err := wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := k8s.Get(ctx, apiSchemeResourceName, config.OperatorNamespace, &apiScheme); err != nil {
 				return false, nil
 			}


### PR DESCRIPTION
This PR is part of a larger effort to stabilize the ROSA operator tests.

It simply updates the deprecated `wait.PollImmediate` method to use `wait.PollUntilContextTimeout`, instead.

This was tested locally.

https://issues.redhat.com/browse/OSD-29385