### PR TITLE
Update deprecated wait.PollImmediate method

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 
 ENV USER_UID=1001 \
     USER_NAME=cloud-ingress-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.It("ensures apischemes CR instance are present on cluster", func(ctx context.Context) {
-		err := wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := k8s.Get(ctx, apiSchemeResourceName, config.OperatorNamespace, &apiScheme); err != nil {
 				return false, nil
 			}


### PR DESCRIPTION
This PR is part of a larger effort to stabilize the ROSA operator tests.

It simply updates the deprecated wait.PollImmediate method to use wait.PollUntilContextTimeout, instead.

This was tested locally.

https://issues.redhat.com/browse/OSD-29385