### PR TITLE
SREP-832 fix integration tests failures

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
 
 ENV USER_UID=1001 \
     USER_NAME=cloud-ingress-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -395,12 +395,6 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "New "+cioServiceName+" forwarding rule not created in GCP")
 		}
 	})
-
-	ginkgo.It("can be upgraded", func(ctx context.Context) {
-		ginkgo.By("forcing operator upgrade")
-		err := k8s.UpgradeOperator(ctx, config.OperatorName, config.OperatorNamespace)
-		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
-	})
 })
 
 // getLBForService retrieves the load balancer name or IP associated with a service of type LoadBalancer


### PR DESCRIPTION
What type of PR:
Update to tests.

Why:
I am Deleting the upgrade tests because this test is currently failing. When skipRange was added to https://github.com/openshift/cloud-ingress-operator/pull/364/ the tests started failing. 

skipRange being enabled is what causes the upgrade tests to no longer work. They worked by querying the OLM bundle to see N-1 then forcing a reinstall of it then watching OLM upgrade. With the skiprange enabled, only a single version OLM bundles if produced, so we don't know what to look at to get N-1

It was decided there was no value in changing the osde2e tests so this is why we deleting the upgrade test over Using ginkgo.PIt to set it in pending.