### PR TITLE
SREP-1450: Replace deprecated MultiNamespacedCacheBuilder usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,9 +109,15 @@ func main() {
 	}
 
 	if strings.Contains(watchNamespace, ",") {
-		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
-		// nolint:golint,all
-		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))
+		nsList := strings.Split(watchNamespace, ",")
+		options.Namespace = map[string]cache.Config{}
+		for _, ns := range nsList {
+			ns = strings.TrimSpace(ns)
+			if ns != "" {
+				options.Cache.DefaultNamespaces[ns] = cache.Config{}
+			}
+		}
+		setupLog.Info("manager set up with multiple namespaces", "namespaces", nsList)
 	}
 
 	ctx := context.TODO()

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func getWatchNamespaces() ([]string, error) {
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
+	const watchNamespaceEnvVar = "WATCH_NAMESPACE"
 	namespaces, found := os.LookupEnv(watchNamespaceEnvVar)
 	if !found {
 		return nil, fmt.Errorf("%s must be set", watchNamespaceEnvVar)


### PR DESCRIPTION
This PR replaces the deprecated `cache.MultiNamespacedCacheBuilder` function to ensure future compatibility with newer `controller-runtime` versions. I performed manual testing  by following steps to verify the changes.

- Removed existing OLM-managed `cloud-ingress-controller` from the cluster
- Built the operator image from this branch locally using `make docker-build`
- Tagged and pushed the image to Quay.
- Updated `deploy/50_cloud-ingress-operator.Deployment.yaml` to use the custom image and deployed manually
- Created the required ClusterRoleBinding since this was a manual deployment.
- Verified the operator pod came up successfully and logs were clean.
- Applied a test PublishingStrategy CR with both default (external) and apps2(internal) ingress configurations
- Validated that `default` ingresscontroller was updated as expected and a new  `apps2` ingresscontroller was created and reflected the internal configuration.

Everything worked as expected, safe to proceed. 