### PR TITLE
Fix cloud-ingress-operator CI deployment issues

### DIFF
--- a/deploy/20_cloud-ingress-operator.ClusterRole.yaml
+++ b/deploy/20_cloud-ingress-operator.ClusterRole.yaml
@@ -22,3 +22,28 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - publishingstrategies
+  - apischemes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/deploy/25_cloud-ingress-operator.ClusterRoleBinding.yaml
+++ b/deploy/25_cloud-ingress-operator.ClusterRoleBinding.yaml
@@ -1,13 +1,12 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: cloud-ingress-operator
-  namespace: openshift-cloud-ingress-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-ingress-operator
 subjects:
 - kind: ServiceAccount
   name: cloud-ingress-operator
   namespace: openshift-cloud-ingress-operator
-roleRef:
-  kind: Role
-  name: cloud-ingress-operator
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Added missing ClusterRoleBinding for ServiceAccount permissions
- Added missing RBAC permissions for cloudingress.managed.openshift.io and services
- Fixed RoleBinding syntax error (remove invalid namespace from roleRef)
- Replaced REPLACE_IMAGE placeholder with working container image

Fixes CI failures where operator deployment fails due to incomplete RBAC setup.

fixes :[SREP-1576](https://issues.redhat.com//browse/SREP-1576)