### PR TITLE
[SREP-2115] Add all namespace-scoped resource types to cache configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ import (
 	apischemecontroller "github.com/openshift/cloud-ingress-operator/controllers/apischeme"
 	publishingstrategycontroller "github.com/openshift/cloud-ingress-operator/controllers/publishingstrategy"
 	routerservicecontroller "github.com/openshift/cloud-ingress-operator/controllers/routerservice"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	//+kubebuilder:scaffold:imports
 )
@@ -129,6 +130,18 @@ func main() {
 					Namespaces: namespaces,
 				},
 				&corev1.Secret{}: {
+					Namespaces: namespaces,
+				},
+				&machinev1beta1.Machine{}: {
+					Namespaces: namespaces,
+				},
+				&machinev1beta1.MachineSet{}: {
+					Namespaces: namespaces,
+				},
+				&machinev1.ControlPlaneMachineSet{}: {
+					Namespaces: namespaces,
+				},
+				&appsv1.Deployment{}: {
 					Namespaces: namespaces,
 				},
 			},


### PR DESCRIPTION
## Summary

This is a comprehensive fix for RBAC errors caused by missing resource types in the controller-runtime cache configuration. This supersedes PR #416 which only addressed Secrets.

### Errors Fixed

```
failed to list *v1.Secret: secrets is forbidden: User "..." cannot list resource "secrets" at the cluster scope
failed to list *v1beta1.Machine: machines.machine.openshift.io is forbidden: User "..." cannot list resource "machines" at the cluster scope
```

(Plus potential errors for MachineSet, ControlPlaneMachineSet, and Deployment)

## Root Cause

Controller-runtime v0.19.0 (upgraded in commit 8550732) uses a delegating cache architecture where:
- Resource types in `ByObject` map get namespace-scoped caches
- Resource types NOT in `ByObject` fall through to cluster-wide default cache
- This triggers RBAC violations when operator lacks cluster-wide permissions

## Changes

### Added to Cache Configuration (main.go:118-148)

**New resource types added:**
- `Secret` - Cloud credentials in openshift-cloud-ingress-operator
- `Machine` - Machine objects in openshift-machine-api
- `MachineSet` - MachineSet objects in openshift-machine-api  
- `ControlPlaneMachineSet` - CPMS objects in openshift-machine-api
- `Deployment` - Deployment objects in multiple namespaces

**Already configured (unchanged):**
- `IngressController` 
- `PublishingStrategy`
- `APIScheme`
- `Service`

### Import Added
- `appsv1 "k8s.io/api/apps/v1"` - For Deployment type

## RBAC Alignment

All added resource types have corresponding namespace-scoped Role permissions:
- **Secrets**: `deploy/20_cloud-ingress-operator.Role.yaml` (openshift-cloud-ingress-operator namespace)
- **Machines/MachineSets/CPMS**: `resources/20_cloud-ingress-operator_machine.Role.yaml` (openshift-machine-api namespace)
- **Deployments**: Multiple role files for various namespaces

This fix ensures cache scope matches RBAC scope, preventing cluster-wide access attempts.

## Testing

- ✅ `make go-build` - Build successful
- ✅ `make go-test` - All tests pass
- ✅ Verified all added resources have namespace-scoped RBAC permissions
- ✅ Verified all namespaces are in WATCH_NAMESPACE

## Deployment Impact

This should resolve all remaining "is forbidden...at the cluster scope" errors for namespace-scoped resources accessed by the operator.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)