### PR TITLE
SREP-2115: Ensure DNS zones IDs are sanitized before calling GCP APIs.

### DIFF
--- a/pkg/cloudclient/gcp/private_test.go
+++ b/pkg/cloudclient/gcp/private_test.go
@@ -156,3 +156,16 @@ func TestGCPProviderDecodeEncode(t *testing.T) {
 	}
 
 }
+
+func Test_sanitizeZoneID(t *testing.T) {
+	zoneIdSanitized := "cs-ci-jsm5n-7zbzx-private-zone"
+	zoneIdUnsanitized := "projects/sda-ccs-3/managedZones/cs-ci-jsm5n-7zbzx-private-zone"
+
+	if sanitizeZoneID(zoneIdSanitized) != zoneIdSanitized {
+		t.Fatalf("sanitizeZoneId() sanitized an already sanitized zone ID")
+	}
+
+	if sanitizeZoneID(zoneIdUnsanitized) != zoneIdSanitized {
+		t.Fatalf("sanitizeZoneId() did not return a sanitized zone ID")
+	}
+}


### PR DESCRIPTION
In OpenShift 4.20, it looks like the format of the zone ID name changed to include a full resource reference instead of just the zone name. This caused CIO to look up with that full resource name, and get a 404 back.

This change ensures that we only use the zone name from that string, and supports both pre and post that change.

Sample `dns` object:
```yaml
apiVersion: config.openshift.io/v1
kind: DNS
metadata:
  generation: 1
  name: cluster
spec:
  baseDomain: cs-ci-jsm5n.xraf.i2.devshift.org
  platform:
    type: ""
  privateZone:
    id: projects/sda-ccs-3/managedZones/cs-ci-jsm5n-7zbzx-private-zone
  publicZone:
    id: projects/sda-ccs-3/managedZones/hive-xraf-i2-devshift-org
```