### PR TITLE
SREP-2115: Ensure DNS zones IDs are sanitized before calling GCP APIs, round 2

### DIFF
--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -164,6 +164,8 @@ func (gc *Client) ensureDNSForService(kclient k8s.Client, svc *corev1.Service, d
 			Additions: []*gdnsv1.ResourceRecordSet{newRRSet},
 		}
 
+		zone.ID = sanitizeZoneID(zone.ID)
+
 		// Look for an existing resource record set in the zone.
 		listCall := gc.dnsService.ResourceRecordSets.List(gc.projectID, zone.ID)
 		response, err := listCall.Name(FQDN).Do()


### PR DESCRIPTION
Continuation of https://github.com/openshift/cloud-ingress-operator/commit/265e093ae2f9be960daa78e544e4cd09e97f3d3f, I missed one location where the zone ID needed to be sanitized. Searched the files again and confirmed this is the only other one