### PR TITLE
SREP-2115: Ensure DNS zones IDs are sanitized before calling GCP APIs, round 3

### DIFF
--- a/pkg/cloudclient/gcp/private.go
+++ b/pkg/cloudclient/gcp/private.go
@@ -482,6 +482,9 @@ func (gc *Client) updateAPIARecord(kclient k8s.Client, recordName string, newIP 
 	if err != nil {
 		return "", err
 	}
+
+	clusterDNS.Spec.PublicZone.ID = sanitizeZoneID(clusterDNS.Spec.PublicZone.ID)
+
 	pubZoneRecords, err := gc.dnsService.ResourceRecordSets.List(gc.projectID, clusterDNS.Spec.PublicZone.ID).Do()
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve list of ResourceRecordSets from public zone %v : %v", clusterDNS.Spec.PublicZone.ID, err)


### PR DESCRIPTION
The previous fixes here handles the APIScheme controller actions, but the PublishingStrategy which comes after had this one call using the `PublicZone.ID` field, which needed to be sanitized as well.