### PR TITLE
SREP-3576 Complete PKO migration: add missing resources, fix SSS, fix cleanup Job

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -51,11 +51,10 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.image | sha256sum | trunc 8 }}
   namespace: openshift-cloud-ingress-operator
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
   ttlSecondsAfterFinished: 100
   template:

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -56,7 +56,7 @@ metadata:
   annotations:
     package-operator.run/phase: cleanup-deploy
 spec:
-  ttlSecondsAfterFinished: 100
+  ttlSecondsAfterFinished: 172800
   template:
     metadata:
       annotations:

--- a/deploy_pko/ClusterRoleBinding-cloud-ingress-operator.yaml
+++ b/deploy_pko/ClusterRoleBinding-cloud-ingress-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-ingress-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-ingress-operator
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator

--- a/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
+++ b/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
@@ -1,0 +1,51 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cloud-ingress-operator-credentials-aws
+  namespace: openshift-cloud-ingress-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  secretRef:
+    name: cloud-ingress-operator-credentials-aws
+    namespace: openshift-cloud-ingress-operator
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      resource: '*'
+      action:
+      - elasticloadbalancing:*
+      - ec2:DescribeAccountAttributes
+      - ec2:DescribeAddresses
+      - ec2:DescribeInternetGateways
+      - ec2:DescribeSecurityGroups
+      - ec2:DescribeSubnets
+      - ec2:DescribeVpcs
+      - ec2:DescribeVpcClassicLink
+      - ec2:DescribeInstances
+      - ec2:DescribeNetworkInterfaces
+      - ec2:DescribeClassicLinkInstances
+      - ec2:DescribeRouteTables
+      - ec2:AuthorizeSecurityGroupEgress
+      - ec2:AuthorizeSecurityGroupIngress
+      - ec2:CreateSecurityGroup
+      - ec2:DeleteSecurityGroup
+      - ec2:DescribeInstanceAttribute
+      - ec2:DescribeInstanceStatus
+      - ec2:DescribeNetworkAcls
+      - ec2:DescribeSecurityGroups
+      - ec2:RevokeSecurityGroupEgress
+      - ec2:RevokeSecurityGroupIngress
+      - ec2:DescribeTags
+      - ec2:CreateTags
+      - ec2:DeleteTags
+      - route53:ChangeResourceRecordSets
+      - route53:GetHostedZone
+      - route53:GetHostedZoneCount
+      - route53:ListHostedZones
+      - route53:ListHostedZonesByName
+      - route53:ListResourceRecordSets
+      - route53:UpdateHostedZoneComment

--- a/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-gcp.yaml
+++ b/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-gcp.yaml
@@ -1,0 +1,19 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cloud-ingress-operator-credentials-gcp
+  namespace: openshift-cloud-ingress-operator
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  secretRef:
+    name: cloud-ingress-operator-credentials-gcp
+    namespace: openshift-cloud-ingress-operator
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/dns.admin
+    - roles/compute.networkAdmin
+    skipServiceCheck: true

--- a/deploy_pko/Role-cloud-ingress-operator-ingress-operator.yaml
+++ b/deploy_pko/Role-cloud-ingress-operator-ingress-operator.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-ingress-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy_pko/Role-cloud-ingress-operator-ingress.yaml
+++ b/deploy_pko/Role-cloud-ingress-operator-ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-ingress
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy_pko/Role-cloud-ingress-operator-kube-apiserver.yaml
+++ b/deploy_pko/Role-cloud-ingress-operator-kube-apiserver.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-kube-apiserver
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy_pko/Role-cloud-ingress-operator-machine-api.yaml
+++ b/deploy_pko/Role-cloud-ingress-operator-machine-api.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-machine-api
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - controlplanemachinesets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudingress.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy_pko/RoleBinding-cloud-ingress-operator-ingress-operator.yaml
+++ b/deploy_pko/RoleBinding-cloud-ingress-operator-ingress-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-ingress-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+roleRef:
+  kind: Role
+  name: cloud-ingress-operator
+  namespace: openshift-ingress-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/RoleBinding-cloud-ingress-operator-ingress.yaml
+++ b/deploy_pko/RoleBinding-cloud-ingress-operator-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-ingress
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+roleRef:
+  kind: Role
+  name: cloud-ingress-operator
+  namespace: openshift-ingress
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/RoleBinding-cloud-ingress-operator-kube-apiserver.yaml
+++ b/deploy_pko/RoleBinding-cloud-ingress-operator-kube-apiserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-kube-apiserver
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+roleRef:
+  kind: Role
+  name: cloud-ingress-operator
+  namespace: openshift-kube-apiserver
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/RoleBinding-cloud-ingress-operator-machine-api.yaml
+++ b/deploy_pko/RoleBinding-cloud-ingress-operator-machine-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-machine-api
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
+subjects:
+- kind: ServiceAccount
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+roleRef:
+  kind: Role
+  name: cloud-ingress-operator
+  namespace: openshift-machine-api
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -26,7 +26,7 @@ objects:
         managed.openshift.io/gitHash: ${IMAGE_TAG}
         managed.openshift.io/gitRepoName: ${REPO_NAME}
         managed.openshift.io/osd: "true"
-      name: cloud-ingress-operator-stage
+      name: cloud-ingress-operator-pko
     spec:
       clusterDeploymentSelector:
         matchLabels:
@@ -50,6 +50,12 @@ objects:
           - "true"
       resourceApplyMode: Sync
       resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            labels:
+              openshift.io/cluster-monitoring: 'true'
+            name: ${NAMESPACE}
         - apiVersion: package-operator.run/v1alpha1
           kind: ClusterPackage
           metadata:

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -66,9 +66,3 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
-        - apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: ${NAMESPACE}
-            labels:
-              openshift.io/cluster-monitoring: 'true'


### PR DESCRIPTION
## Summary
- Adds the operator `Namespace` resource to the PKO SelectorSyncSet in `hack/pko/clusterpackage.yaml`, before the `ClusterPackage` entry. Without this, removing the OLM SSS during migration would delete the namespace fleet-wide (exact ITN-2026-00093 pattern).
- Renames the SSS from `cloud-ingress-operator-stage` to `cloud-ingress-operator-pko` for production readiness.
- Converts OLM cleanup Job to `.gotmpl` with a hashed name (`olm-cleanup-{{ hash }}`) to prevent `spec.template: field is immutable` errors across PKO upgrades. Removes `collision-protection` from the Job (unique names prevent collision); keeps it on ServiceAccount/Role/RoleBinding.
- Adds 11 missing resources to `deploy_pko/` that `make pko-migrate` missed from the OLM SSS template and CSV:
  - 2 CredentialsRequests (AWS + GCP)
  - 4 cross-namespace Role/RoleBinding pairs (openshift-machine-api, openshift-kube-apiserver, openshift-ingress, openshift-ingress-operator)
  - 1 ClusterRoleBinding (auto-generated by OLM from CSV permissions, needed for the ServiceAccount to bind to its ClusterRole)

## Why
The PKO migration was incomplete — `make pko-migrate` only captures resources from the CSV/bundle, not from the SelectorSyncSet template. The OLM SSS template contains the operator Namespace, CredentialsRequests, and cross-namespace RBAC that the script doesn't know about. Additionally, OLM auto-generates ClusterRoleBindings from the CSV permissions section, which also need to be explicitly included in the PKO package.

## Merge ordering
**This PR should merge after** the companion app-interface MR (!180527) that fixes `managedResourceTypes` from `ClusterPackage` to `SelectorSyncSet`. Without that fix, the SSS rename would orphan the old `cloud-ingress-operator-stage` SSS (app-sre wouldn't know to GC a SelectorSyncSet).

## Supersedes
This PR supersedes #449 — that PR adds the same missing resources but uses a `credentials` phase annotation that doesn't exist in `manifest.yaml` (only `crds`, `namespace`, `rbac`, `deploy`, `cleanup-rbac`, `cleanup-deploy` are defined), which would break the ClusterPackage deployment.

## Test plan
- [ ] Verify the app-interface `managedResourceTypes` MR merges first
- [ ] After merge, confirm integration hive deploys the new SSS (`cloud-ingress-operator-pko`) with the `Namespace` resource
- [ ] Confirm the old `cloud-ingress-operator-stage` SSS is cleaned up by app-sre
- [ ] Verify operator pods remain running on managed clusters
- [ ] Verify OLM cleanup Job name includes the image hash suffix
- [ ] Verify CredentialsRequests exist on managed clusters: `oc get credentialsrequest -n openshift-cloud-ingress-operator`
- [ ] Verify cross-namespace Roles exist: `oc get role cloud-ingress-operator -n openshift-machine-api`, etc.
- [ ] Verify ClusterRoleBinding exists: `oc get clusterrolebinding cloud-ingress-operator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)