### PR TITLE
SREP-1550 Fix GCP address deletion using resource name instead of IP

### DIFF
--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -335,12 +335,22 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 			}
 
 			ginkgo.By("Deleting GCP address for " + cioServiceName)
-			if op, err := computeService.Addresses.Delete(project, region, oldLBIP).Do(); err != nil {
-				log.Printf("Address already deleted or not found: %v", err)
-			} else {
-				_, err = computeService.RegionOperations.Wait(project, region, op.Name).Do()
-				Expect(err).NotTo(HaveOccurred(), "Timed out waiting for address deletion")
-				log.Printf("Address deleted")
+			// Addresses.Delete expects a resource name, not an IP.
+			// Look up the address resource whose .Address matches oldLBIP.
+			addressList, err := computeService.Addresses.List(project, region).Do()
+			Expect(err).NotTo(HaveOccurred(), "Could not list GCP addresses")
+			for _, addr := range addressList.Items {
+				if addr.Address == oldLBIP {
+					log.Printf("Found address resource %s for IP %s", addr.Name, oldLBIP)
+					if op, err := computeService.Addresses.Delete(project, region, addr.Name).Do(); err != nil {
+						log.Printf("Address already deleted or not found: %v", err)
+					} else {
+						_, err = computeService.RegionOperations.Wait(project, region, op.Name).Do()
+						Expect(err).NotTo(HaveOccurred(), "Timed out waiting for address deletion")
+						log.Printf("Address %s deleted", addr.Name)
+					}
+					break
+				}
 			}
 
 			newLBIP := ""


### PR DESCRIPTION
## Summary

Fixes the root cause of the persistent GCP e2e LB reconciliation test failure. Follow-up to #450 and #452.

`Addresses.Delete(project, region, name)` expects a **resource name**, but the test was passing the **IP address** (e.g. `34.75.221.55`), causing a GCP API 400 error. The error was silently logged, leaving the address reservation in place. When the operator recreated the rh-api Service, GCP assigned the same IP from the persisting reservation, so `newLBIP == oldLBIP` and the test waited forever.

Fix: list addresses in the region, find the one whose `.Address` matches the old LB IP, then delete by `.Name`.

## Test plan

- [x] `go build -tags=osde2e ./test/e2e/` compiles
- [ ] GCP e2e test passes on integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)