### PR TITLE
Change old SSS to upsert.

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -51,7 +51,7 @@ objects:
         operator: NotIn
         values:
         - "true"
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
     - kind: Namespace


### PR DESCRIPTION
This way the namespace will not be terminated when moving to PKO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified configuration application behavior to better preserve existing resource customizations during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->