### PR TITLE
Update CredentialsRequests

### DIFF
--- a/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
+++ b/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
@@ -17,35 +17,15 @@ spec:
     - effect: Allow
       resource: '*'
       action:
-      - elasticloadbalancing:*
-      - ec2:DescribeAccountAttributes
-      - ec2:DescribeAddresses
-      - ec2:DescribeInternetGateways
-      - ec2:DescribeSecurityGroups
-      - ec2:DescribeSubnets
-      - ec2:DescribeVpcs
-      - ec2:DescribeVpcClassicLink
+      - elasticloadbalancing:DescribeLoadBalancers
+      - elasticloadbalancing:DescribeTags
+      - elasticloadbalancing:DeleteLoadBalancer
+      - elasticloadbalancing:CreateLoadBalancer
+      - elasticloadbalancing:CreateListener
+      - elasticloadbalancing:DescribeTargetGroups
       - ec2:DescribeInstances
-      - ec2:DescribeNetworkInterfaces
-      - ec2:DescribeClassicLinkInstances
+      - ec2:DescribeSubnets
       - ec2:DescribeRouteTables
-      - ec2:AuthorizeSecurityGroupEgress
-      - ec2:AuthorizeSecurityGroupIngress
-      - ec2:CreateSecurityGroup
-      - ec2:DeleteSecurityGroup
-      - ec2:DescribeInstanceAttribute
-      - ec2:DescribeInstanceStatus
-      - ec2:DescribeNetworkAcls
-      - ec2:DescribeSecurityGroups
-      - ec2:RevokeSecurityGroupEgress
-      - ec2:RevokeSecurityGroupIngress
-      - ec2:DescribeTags
-      - ec2:CreateTags
-      - ec2:DeleteTags
       - route53:ChangeResourceRecordSets
-      - route53:GetHostedZone
-      - route53:GetHostedZoneCount
-      - route53:ListHostedZones
-      - route53:ListHostedZonesByName
       - route53:ListResourceRecordSets
-      - route53:UpdateHostedZoneComment
+      - route53:ListHostedZonesByName

--- a/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
+++ b/deploy_pko/CredentialsRequest-cloud-ingress-operator-credentials-aws.yaml
@@ -19,6 +19,7 @@ spec:
       action:
       - elasticloadbalancing:DescribeLoadBalancers
       - elasticloadbalancing:DescribeTags
+      - elasticloadbalancing:AddTags
       - elasticloadbalancing:DeleteLoadBalancer
       - elasticloadbalancing:CreateLoadBalancer
       - elasticloadbalancing:CreateListener

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -78,6 +78,7 @@ objects:
             action:
             - elasticloadbalancing:DescribeLoadBalancers
             - elasticloadbalancing:DescribeTags
+            - elasticloadbalancing:AddTags
             - elasticloadbalancing:DeleteLoadBalancer
             - elasticloadbalancing:CreateLoadBalancer
             - elasticloadbalancing:CreateListener

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -76,38 +76,18 @@ objects:
           - effect: Allow
             resource: '*'
             action:
-            - elasticloadbalancing:*
-            - ec2:DescribeAccountAttributes
-            - ec2:DescribeAddresses
-            - ec2:DescribeInternetGateways
-            - ec2:DescribeSecurityGroups
-            - ec2:DescribeSubnets
-            - ec2:DescribeVpcs
-            - ec2:DescribeVpcClassicLink
+            - elasticloadbalancing:DescribeLoadBalancers
+            - elasticloadbalancing:DescribeTags
+            - elasticloadbalancing:DeleteLoadBalancer
+            - elasticloadbalancing:CreateLoadBalancer
+            - elasticloadbalancing:CreateListener
+            - elasticloadbalancing:DescribeTargetGroups
             - ec2:DescribeInstances
-            - ec2:DescribeNetworkInterfaces
-            - ec2:DescribeClassicLinkInstances
+            - ec2:DescribeSubnets
             - ec2:DescribeRouteTables
-            - ec2:AuthorizeSecurityGroupEgress
-            - ec2:AuthorizeSecurityGroupIngress
-            - ec2:CreateSecurityGroup
-            - ec2:DeleteSecurityGroup
-            - ec2:DescribeInstanceAttribute
-            - ec2:DescribeInstanceStatus
-            - ec2:DescribeNetworkAcls
-            - ec2:DescribeSecurityGroups
-            - ec2:RevokeSecurityGroupEgress
-            - ec2:RevokeSecurityGroupIngress
-            - ec2:DescribeTags
-            - ec2:CreateTags
-            - ec2:DeleteTags
             - route53:ChangeResourceRecordSets
-            - route53:GetHostedZone
-            - route53:GetHostedZoneCount
-            - route53:ListHostedZones
-            - route53:ListHostedZonesByName
             - route53:ListResourceRecordSets
-            - route53:UpdateHostedZoneComment
+            - route53:ListHostedZonesByName
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest
       metadata:


### PR DESCRIPTION
```make go-test
boilerplate/openshift/golang-osd-operator/standard.mk:107: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
Setting up kubebuilder test assets...
Using test assets: /tmp/envtest-binaries/k8s/1.28.0-linux-amd64
ok  	github.com/openshift/cloud-ingress-operator	1.669s
?   	github.com/openshift/cloud-ingress-operator/api/v1alpha1	[no test files]
?   	github.com/openshift/cloud-ingress-operator/config	[no test files]
ok  	github.com/openshift/cloud-ingress-operator/controllers/apischeme	1.134s
ok  	github.com/openshift/cloud-ingress-operator/controllers/publishingstrategy	2.653s
ok  	github.com/openshift/cloud-ingress-operator/controllers/routerservice	1.947s
ok  	github.com/openshift/cloud-ingress-operator/pkg/cloudclient	3.188s
ok  	github.com/openshift/cloud-ingress-operator/pkg/cloudclient/aws	4.308s
ok  	github.com/openshift/cloud-ingress-operator/pkg/cloudclient/gcp	3.721s
?   	github.com/openshift/cloud-ingress-operator/pkg/cloudclient/mock_cloudclient	[no test files]
?   	github.com/openshift/cloud-ingress-operator/pkg/controllerutils	[no test files]
?   	github.com/openshift/cloud-ingress-operator/pkg/errors	[no test files]
?   	github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller	[no test files]
?   	github.com/openshift/cloud-ingress-operator/pkg/localmetrics	[no test files]
?   	github.com/openshift/cloud-ingress-operator/pkg/testutils	[no test files]
ok  	github.com/openshift/cloud-ingress-operator/pkg/utils	4.720s```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * AWS access permissions are now more narrowly scoped to the load balancer, networking, and DNS actions required by ingress functionality.
  * Reduced broad permissions for Elastic Load Balancing, EC2, and Route 53 services.
  * Removed unnecessary permissions for security groups, network interfaces, VPCs, and hosted zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->