### PR TITLE
ROSAENG-61838: Poll for APIScheme CR before CIDR block test

### DIFF
--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -85,8 +85,14 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.It("reconciles cidr block changes in apischeme with rh-api service", func(ctx context.Context) {
-		err := k8s.Get(ctx, apiSchemeResourceName, config.OperatorNamespace, &apiScheme)
-		Expect(err).NotTo(HaveOccurred(), "Could not get apischeme CR instance")
+		ginkgo.By("Waiting for apischeme CR to be available")
+		err := wait.PollUntilContextTimeout(ctx, pollingInterval, pollingDuration, true, func(ctx context.Context) (bool, error) {
+			if err := k8s.Get(ctx, apiSchemeResourceName, config.OperatorNamespace, &apiScheme); err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		Expect(err).NotTo(HaveOccurred(), "Could not get apischeme CR instance after polling")
 		originalCidrBlock := make([]string, len(apiScheme.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks))
 		copy(originalCidrBlock, apiScheme.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks)
 		updatedApiScheme := apiScheme.DeepCopy()


### PR DESCRIPTION
## Summary

Two fixes for CIO e2e tests running in Prow on CI lease clusters:

1. **Poll for APIScheme CR**: Replace synchronous `k8s.Get()` with `wait.PollUntilContextTimeout` for the `rh-api` APIScheme CR in the CIDR block test. After PKO reinstalls the operator, the SelectorSyncSet needs time to re-sync.

2. **Seed rh-api fixture on CI clusters**: On CI lease clusters, the `rh-api` APIScheme CR does not exist because it is normally created by a SelectorSyncSet on production managed clusters. The BeforeAll now seeds a minimal `rh-api` APIScheme CR if it is not found, so the CIDR block reconciliation test has something to test against.

## Test plan

- [x] `go test ./test/e2e -c --tags=osde2e` compiles clean
- [ ] Prow rehearsal of `rosa-osd-aws-e2e` in openshift/release#83681 passes after this merges

Jira: https://redhat.atlassian.net/browse/ROSAENG-61838