### PR TITLE
ROSAENG-61838: Use 2 CIDR blocks in seeded APIScheme fixture

### DIFF
--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 					ManagementAPIServerIngress: cloudingressv1alpha1.ManagementAPIServerIngress{
 						Enabled:           true,
 						DNSName:           "rh-api",
-						AllowedCIDRBlocks: []string{"10.0.0.0/8"},
+						AllowedCIDRBlocks: []string{"10.0.0.0/8", "172.16.0.0/12"},
 					},
 				},
 			}


### PR DESCRIPTION
## Summary

The CIDR block reconciliation test removes one entry from `AllowedCIDRBlocks` and verifies the service reflects the change. With only 1 CIDR block in the seeded fixture (#525), the test produces an empty slice which fails `BeEquivalentTo` against `nil` (Go nil vs empty slice distinction).

Uses 2 CIDR blocks (`10.0.0.0/8`, `172.16.0.0/12`) so removing one leaves a non-empty slice that compares correctly.

## Test plan

- [x] `go test ./test/e2e -c --tags=osde2e` compiles clean
- [ ] Prow rehearsal of `rosa-osd-aws-e2e` in openshift/release#83681 passes after this merges

Jira: https://redhat.atlassian.net/browse/ROSAENG-61838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated cloud ingress test coverage to include an additional permitted private network range.
  - Improved validation of ingress behavior across multiple CIDR blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->