### PR TITLE
ROSAENG-61838: Fix conflict error reverting APIScheme in CIDR block test

### DIFF
--- a/test/e2e/cloud_ingress_operator_tests.go
+++ b/test/e2e/cloud_ingress_operator_tests.go
@@ -151,11 +151,25 @@ var _ = ginkgo.Describe("cloud-ingress-operator", ginkgo.Ordered, func() {
 		copy(originalCidrBlock, apiScheme.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks)
 		updatedApiScheme := apiScheme.DeepCopy()
 
-		// Restore CIDR blocks when the test completes, regardless of outcome
+		// Restore CIDR blocks when the test completes, regardless of outcome.
+		// Re-fetch before update to avoid conflict errors from concurrent
+		// operator reconciliation.
 		defer func() {
-			updatedApiScheme.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks = originalCidrBlock
-			err = k8s.Update(ctx, updatedApiScheme)
-			Expect(err).NotTo(HaveOccurred(), "Could not revert APIScheme CR instance")
+			for attempt := 0; attempt < 5; attempt++ {
+				var fresh cloudingressv1alpha1.APIScheme
+				if getErr := k8s.Get(ctx, apiSchemeResourceName, config.OperatorNamespace, &fresh); getErr != nil {
+					log.Printf("Warning: could not re-fetch APIScheme for revert: %v", getErr)
+					return
+				}
+				fresh.Spec.ManagementAPIServerIngress.AllowedCIDRBlocks = originalCidrBlock
+				if updateErr := k8s.Update(ctx, &fresh); updateErr == nil {
+					return
+				} else if !apierrors.IsConflict(updateErr) {
+					log.Printf("Warning: could not revert APIScheme CR: %v", updateErr)
+					return
+				}
+				log.Printf("Conflict reverting APIScheme, retrying (attempt %d)", attempt+1)
+			}
 		}()
 
 		updatedCidrBlock := make([]string, len(originalCidrBlock)-1)


### PR DESCRIPTION
## Summary

The CIDR block test's `defer` block restores original CIDR blocks using a stale `updatedApiScheme` object. By cleanup time, the operator has reconciled the CR concurrently, making the `resourceVersion` stale and causing a conflict error.

Fix: re-fetch the CR before updating, retry on conflict up to 5 times, and make revert errors best-effort (log warning instead of failing the suite).

## Test plan

- [x] `go test ./test/e2e -c --tags=osde2e` compiles clean
- [ ] `rosa-osd-aws-e2e` presubmit passes on PR #528 after this merges

Jira: https://redhat.atlassian.net/browse/ROSAENG-61838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CIDR restoration cleanup reliability by refreshing the current configuration before updates.
  - Added retries for update conflicts, reducing failures caused by concurrent changes.
  - Cleanup now logs errors and exits gracefully instead of failing the test unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->